### PR TITLE
feat: 電気料金シミュレーションサービスを実装

### DIFF
--- a/serverside_challenge_2/challenge/.rubocop.yml
+++ b/serverside_challenge_2/challenge/.rubocop.yml
@@ -64,6 +64,7 @@ Rails/FindEach:
 RSpec/DescribeClass:
   Exclude:
     - "spec/data_consistency_spec.rb"
+    - "spec/requests/**/*"
 
 RSpec/IteratedExpectation:
   Exclude:

--- a/serverside_challenge_2/challenge/app/controllers/api/v1/electricity_bill_simulations_controller.rb
+++ b/serverside_challenge_2/challenge/app/controllers/api/v1/electricity_bill_simulations_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ElectricityBillSimulationsController < ApplicationController
+      def index
+        form = ElectricityBillSimulationParams.new(params.permit(:ampere, :kwh))
+        return render_validation_errors(form) if form.invalid?
+
+        results = ElectricityBillSimulator.call(ampere: form.ampere, kwh: form.kwh)
+        render json: { data: results }, status: :ok
+      end
+
+      private
+
+      def render_validation_errors(form)
+        render json: { errors: form.jsonapi_errors }, status: :bad_request
+      end
+    end
+  end
+end

--- a/serverside_challenge_2/challenge/app/forms/electricity_bill_simulation_params.rb
+++ b/serverside_challenge_2/challenge/app/forms/electricity_bill_simulation_params.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ElectricityBillSimulationParams
+  include ActiveModel::Model
+
+  AMPERE_VALUES = [10, 15, 20, 30, 40, 50, 60].freeze
+  MAX_KWH = 9_999
+
+  attr_writer :ampere, :kwh
+
+  validates :ampere, presence: true,
+                     inclusion: { in: AMPERE_VALUES, allow_blank: true }
+  validates :kwh, presence: true,
+                  numericality: {
+                    only_integer: true,
+                    greater_than_or_equal_to: 0,
+                    less_than_or_equal_to: MAX_KWH,
+                    allow_blank: true
+                  }
+
+  def ampere
+    cast_to_integer(@ampere)
+  end
+
+  def kwh
+    cast_to_integer(@kwh)
+  end
+
+  def jsonapi_errors
+    errors.map do |error|
+      {
+        status: '400',
+        title: I18n.t('electricity_bill_simulations.errors.title'),
+        detail: error.full_message,
+        source: { parameter: error.attribute.to_s }
+      }
+    end
+  end
+
+  private
+
+  def cast_to_integer(value)
+    return nil if value.nil? || value == ''
+
+    Integer(value.to_s, 10)
+  rescue ArgumentError
+    value
+  end
+end

--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -38,7 +38,7 @@ class ElectricityBillSimulator
     [plan, (base + usage_price(plan)).floor.to_i]
   end
 
-  # 従量課金のみプラン (Looop) は基本料金 0、それ以外は ampere 一致レコードが無ければ nil
+  # 従量課金のみプランは基本料金 0、それ以外は ampere 一致レコードが無ければ nil
   def base_price(plan)
     return BigDecimal(0) if plan.metered_only?
 

--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -9,8 +9,8 @@ class ElectricityBillSimulator
   end
 
   def initialize(ampere:, kwh:)
-    @ampere = Integer(ampere)
-    @kwh = Integer(kwh)
+    @ampere = parse_integer!(ampere, :ampere)
+    @kwh = parse_integer!(kwh, :kwh)
 
     validate!
   end
@@ -23,6 +23,12 @@ class ElectricityBillSimulator
   end
 
   private
+
+  def parse_integer!(value, name)
+    raise ArgumentError, "#{name} must be an integer (got #{value.inspect})" if value.is_a?(Float)
+
+    Integer(value)
+  end
 
   def validate!
     unless VALID_AMPERES.include?(@ampere)

--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -2,6 +2,7 @@
 
 class ElectricityBillSimulator
   VALID_AMPERES = [10, 15, 20, 30, 40, 50, 60].freeze
+  MAX_KWH = 9999
 
   def self.call(ampere:, kwh:)
     new(ampere: ampere, kwh: kwh).call
@@ -27,7 +28,7 @@ class ElectricityBillSimulator
     unless VALID_AMPERES.include?(@ampere)
       raise ArgumentError, "ampere must be one of #{VALID_AMPERES} (got #{@ampere})"
     end
-    raise ArgumentError, "kwh must be greater than or equal to 0 (got #{@kwh})" if @kwh.negative?
+    raise ArgumentError, "kwh must be between 0 and #{MAX_KWH} (got #{@kwh})" unless (0..MAX_KWH).cover?(@kwh)
   end
 
   # アンペア非対応プランは nil を返し、filter_map で除外する

--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class ElectricityBillSimulator
+  VALID_AMPERES = [10, 15, 20, 30, 40, 50, 60].freeze
+
+  def self.call(ampere:, kwh:)
+    new(ampere: ampere, kwh: kwh).call
+  end
+
+  def initialize(ampere:, kwh:)
+    @ampere = Integer(ampere)
+    @kwh = Integer(kwh)
+
+    validate!
+  end
+
+  def call
+    Plan.all
+        .filter_map { |plan| pair_with_price(plan) }
+        .sort_by { |plan, price| [price, plan.provider_id, plan.id] }
+        .map { |plan, price| { provider_name: plan.provider.name, plan_name: plan.name, price: price } }
+  end
+
+  private
+
+  def validate!
+    unless VALID_AMPERES.include?(@ampere)
+      raise ArgumentError, "ampere must be one of #{VALID_AMPERES} (got #{@ampere})"
+    end
+    raise ArgumentError, "kwh must be greater than or equal to 0 (got #{@kwh})" if @kwh.negative?
+  end
+
+  # アンペア非対応プランは nil を返し、filter_map で除外する
+  def pair_with_price(plan)
+    base = base_price(plan)
+    return nil if base.nil?
+
+    [plan, (base + usage_price(plan)).floor.to_i]
+  end
+
+  # 従量課金のみプラン (Looop) は基本料金 0、それ以外は ampere 一致レコードが無ければ nil
+  def base_price(plan)
+    return BigDecimal(0) if plan.metered_only?
+
+    plan.ampere_based_rates.detect { |r| r.ampere == @ampere }&.rate
+  end
+
+  def usage_price(plan)
+    plan.usage_based_rates.sum(BigDecimal(0)) do |usage_rate|
+      usage_rate.rate * billable_kwh_for(usage_rate)
+    end
+  end
+
+  def billable_kwh_for(usage_rate)
+    upper = [@kwh, usage_rate.kilowatt_hour_high].min
+    consumed = upper - usage_rate.kilowatt_hour_low + 1
+
+    [consumed, 0].max
+  end
+end

--- a/serverside_challenge_2/challenge/config/locales/ja.yml
+++ b/serverside_challenge_2/challenge/config/locales/ja.yml
@@ -1,8 +1,26 @@
 ja:
   activemodel:
+    attributes:
+      electricity_bill_simulation_params:
+        ampere: "ampere"
+        kwh: "kwh"
     errors:
       models:
         usage_based_rate:
           attributes:
             kilowatt_hour_low:
               must_not_exceed_high: は kilowatt_hour_high 以下でなければなりません
+        electricity_bill_simulation_params:
+          attributes:
+            ampere:
+              blank: "は必須です"
+              inclusion: "は 10, 15, 20, 30, 40, 50, 60 のいずれかを指定してください"
+            kwh:
+              blank: "は必須です"
+              not_a_number: "は整数で指定してください"
+              not_an_integer: "は整数で指定してください"
+              greater_than_or_equal_to: "は 0 以上の値を指定してください"
+              less_than_or_equal_to: "は 9999 以下の値を指定してください"
+  electricity_bill_simulations:
+    errors:
+      title: "Invalid Parameter"

--- a/serverside_challenge_2/challenge/config/routes.rb
+++ b/serverside_challenge_2/challenge/config/routes.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  namespace :api do
+    namespace :v1 do
+      resources :electricity_bill_simulations, only: [:index]
+    end
+  end
 end

--- a/serverside_challenge_2/challenge/spec/forms/electricity_bill_simulation_params_spec.rb
+++ b/serverside_challenge_2/challenge/spec/forms/electricity_bill_simulation_params_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ElectricityBillSimulationParams do
+  def build_params(ampere: '30', kwh: '400')
+    described_class.new(ampere: ampere, kwh: kwh)
+  end
+
+  describe 'バリデーション' do
+    context 'with ampere' do
+      it '有効値（30）は valid' do
+        expect(build_params(ampere: '30')).to be_valid
+      end
+
+      it '上限ぎりぎり kwh=9999 は valid' do
+        expect(build_params(kwh: '9999')).to be_valid
+      end
+
+      it 'AMPERE_VALUES に含まれない値（25）は invalid' do
+        params = build_params(ampere: '25')
+        expect(params).to be_invalid
+        expect(params.errors[:ampere]).to include(match(/のいずれかを指定/))
+      end
+
+      it 'ampere が欠落している場合は blank エラー' do
+        params = build_params(ampere: nil)
+        expect(params).to be_invalid
+        expect(params.errors[:ampere]).to include(match(/必須/))
+      end
+
+      it 'ampere が非数値文字列（"abc"）の場合は inclusion エラー' do
+        params = build_params(ampere: 'abc')
+        expect(params).to be_invalid
+        expect(params.errors[:ampere]).to include(match(/のいずれかを指定/))
+      end
+    end
+
+    context 'with kwh' do
+      it 'kwh が欠落している場合は blank エラー' do
+        params = build_params(kwh: nil)
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/必須/))
+      end
+
+      it '負の値（-1）は invalid' do
+        params = build_params(kwh: '-1')
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/0 以上/))
+      end
+
+      it '小数（"100.5"）は invalid' do
+        params = build_params(kwh: '100.5')
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/整数/))
+      end
+
+      it '上限超過（10000）は invalid' do
+        params = build_params(kwh: '10000')
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/9999 以下/))
+      end
+
+      it '非数値文字列（"abc"）は invalid' do
+        params = build_params(kwh: 'abc')
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/整数/))
+      end
+    end
+
+    context 'with multiple invalid params' do
+      it '両方不正（ampere=25, kwh=-1）は 2 件のエラー' do
+        params = build_params(ampere: '25', kwh: '-1')
+        expect(params).to be_invalid
+        expect(params.errors.count).to eq(2)
+      end
+
+      it '両方欠落は 2 件のエラー' do
+        params = build_params(ampere: nil, kwh: nil)
+        expect(params).to be_invalid
+        expect(params.errors.count).to eq(2)
+      end
+    end
+  end
+
+  describe '#jsonapi_errors' do
+    it 'status / title / detail / source.parameter のキーを持つ配列を返す' do
+      params = build_params(ampere: '25')
+      params.valid?
+
+      error = params.jsonapi_errors.first
+      expect(error[:status]).to eq('400')
+      expect(error[:title]).to eq('Invalid Parameter')
+      expect(error[:detail]).to be_a(String)
+      expect(error[:source]).to eq({ parameter: 'ampere' })
+    end
+
+    it 'エラーが複数ある場合は全件返す' do
+      params = build_params(ampere: nil, kwh: nil)
+      params.valid?
+
+      expect(params.jsonapi_errors.count).to eq(2)
+    end
+  end
+end

--- a/serverside_challenge_2/challenge/spec/requests/api/v1/electricity_bill_simulations_spec.rb
+++ b/serverside_challenge_2/challenge/spec/requests/api/v1/electricity_bill_simulations_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/electricity_bill_simulations' do
+  let(:valid_params) { { ampere: 30, kwh: 400 } }
+
+  context 'with valid params' do
+    it 'status 200 を返し、data 配列が provider_name / plan_name / price を持つ' do
+      get '/api/v1/electricity_bill_simulations', params: valid_params
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data']).to be_an(Array)
+      expect(json['data']).to all(include('provider_name', 'plan_name', 'price'))
+    end
+  end
+
+  context 'with invalid ampere' do
+    it '不正な ampere で status 400 を返し、errors[0] が JSON:API 形式' do
+      get '/api/v1/electricity_bill_simulations', params: { ampere: 25, kwh: 400 }
+
+      expect(response).to have_http_status(:bad_request)
+      json = response.parsed_body
+      error = json['errors'].first
+      expect(error['status']).to eq('400')
+      expect(error['title']).to eq('Invalid Parameter')
+      expect(error['detail']).to be_a(String)
+      expect(error['source']['parameter']).to eq('ampere')
+    end
+  end
+
+  context 'without params' do
+    it 'パラメータなしで status 400 を返し、errors が 2 件' do
+      get '/api/v1/electricity_bill_simulations'
+
+      expect(response).to have_http_status(:bad_request)
+      json = response.parsed_body
+      expect(json['errors'].count).to eq(2)
+    end
+  end
+end

--- a/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
+++ b/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe ElectricityBillSimulator do
       expect { described_class.call(ampere: 'abc', kwh: 400) }.to raise_error(StandardError)
     end
 
+    it 'float のアンペアで ArgumentError (丸めず弾く)' do
+      expect { described_class.call(ampere: 30.0, kwh: 400) }.to raise_error(ArgumentError, /ampere/)
+    end
+
+    it 'float の kWh で ArgumentError (丸めず弾く)' do
+      expect { described_class.call(ampere: 30, kwh: 400.5) }.to raise_error(ArgumentError, /kwh/)
+    end
+
     it 'Integer-coercible な文字列は正常に計算できる' do
       coerced = described_class.call(ampere: '30', kwh: '400')
       direct = described_class.call(ampere: 30, kwh: 400)

--- a/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
+++ b/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ElectricityBillSimulator do
+  subject(:result) { described_class.call(ampere: ampere, kwh: kwh) }
+
+  def price_for(plan_name, ampere:, kwh:)
+    described_class.call(ampere: ampere, kwh: kwh)
+                   .find { |row| row[:plan_name] == plan_name }[:price]
+  end
+
+  # 基本料金あり + 従量段階制（東京電力エナジーパートナー / 従量電灯B）
+  describe '基本料金あり + 従量段階制 (Plan id=1)' do
+    it '0kWh は基本料金のみ' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 0)).to eq 858
+    end
+
+    it '第1段階の上限 (120kWh)' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 120)).to eq 3243
+    end
+
+    it '第2段階の開始 (121kWh)' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 121)).to eq 3270
+    end
+
+    it '第2段階の上限 (300kWh)' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 300)).to eq 8010
+    end
+
+    it '第3段階の開始 (301kWh)' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 301)).to eq 8040
+    end
+
+    it '複数段階またがり (40A, 400kWh)' do
+      expect(price_for('従量電灯B', ampere: 40, kwh: 400)).to eq 11_353
+    end
+  end
+
+  # 基本料金なし + 従量均一（Looopでんき / おうちプラン）
+  describe '基本料金なし + 従量均一 (Plan id=4: Looop)' do
+    it '0kWh は 0 円' do
+      expect(price_for('おうちプラン', ampere: 30, kwh: 0)).to eq 0
+    end
+
+    it '通常使用 (400kWh)' do
+      expect(price_for('おうちプラン', ampere: 30, kwh: 400)).to eq 11_520
+    end
+  end
+
+  # アンペア非対応プランの除外（東京ガス / ずっとも電気1）
+  describe 'アンペア非対応プランの除外 (Plan id=3: ずっとも電気1)' do
+    let(:plan_names) { result.pluck(:plan_name) }
+
+    context 'when ampere=20A (ずっとも電気1 は非対応)' do
+      let(:ampere) { 20 }
+      let(:kwh) { 400 }
+
+      it 'ずっとも電気1 はレスポンスに含まれない' do
+        expect(plan_names).not_to include('ずっとも電気1')
+      end
+
+      it 'Looop おうちプランは含まれる (metered_only? は基本料金 0 で計算続行)' do
+        expect(plan_names).to include('おうちプラン')
+      end
+    end
+
+    context 'when ampere=30A (ずっとも電気1 は対応)' do
+      let(:ampere) { 30 }
+      let(:kwh) { 400 }
+
+      it 'ずっとも電気1 はレスポンスに含まれる' do
+        expect(plan_names).to include('ずっとも電気1')
+      end
+    end
+  end
+
+  describe '横断' do
+    let(:ampere) { 30 }
+    let(:kwh) { 400 }
+
+    it '全プラン対応のアンペアでは 4 プラン全て返る' do
+      expect(result.size).to eq 4
+    end
+
+    it 'price 昇順で並ぶ' do
+      prices = result.pluck(:price)
+      expect(prices).to eq prices.sort
+    end
+  end
+
+  describe '戻り値の形' do
+    let(:ampere) { 30 }
+    let(:kwh) { 400 }
+
+    it '各要素は :provider_name / :plan_name / :price の 3 キーのみを持つ' do
+      result.each do |row|
+        expect(row.keys).to contain_exactly(:provider_name, :plan_name, :price)
+      end
+    end
+
+    it ':price は Integer' do
+      result.each do |row|
+        expect(row[:price]).to be_a(Integer)
+      end
+    end
+  end
+
+  describe '入力バリデーション' do
+    it 'サポート外のアンペア (25A) で ArgumentError' do
+      expect { described_class.call(ampere: 25, kwh: 400) }.to raise_error(ArgumentError, /ampere/)
+    end
+
+    it '0A (集合外) で ArgumentError' do
+      expect { described_class.call(ampere: 0, kwh: 400) }.to raise_error(ArgumentError, /ampere/)
+    end
+
+    it '負の kWh で ArgumentError' do
+      expect { described_class.call(ampere: 30, kwh: -1) }.to raise_error(ArgumentError, /kwh/)
+    end
+
+    it 'Integer に coerce できないアンペアで例外' do
+      expect { described_class.call(ampere: 'abc', kwh: 400) }.to raise_error(StandardError)
+    end
+
+    it 'Integer-coercible な文字列は正常に計算できる' do
+      coerced = described_class.call(ampere: '30', kwh: '400')
+      direct = described_class.call(ampere: 30, kwh: 400)
+      expect(coerced).to eq direct
+    end
+  end
+end

--- a/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
+++ b/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
@@ -119,6 +119,10 @@ RSpec.describe ElectricityBillSimulator do
       expect { described_class.call(ampere: 30, kwh: -1) }.to raise_error(ArgumentError, /kwh/)
     end
 
+    it 'MAX_KWH を超えた kwh で ArgumentError' do
+      expect { described_class.call(ampere: 30, kwh: 10_000) }.to raise_error(ArgumentError, /kwh/)
+    end
+
     it 'Integer に coerce できないアンペアで例外' do
       expect { described_class.call(ampere: 'abc', kwh: 400) }.to raise_error(StandardError)
     end


### PR DESCRIPTION
Issue #6 の料金計算サービス層を TDD で実装する。

## 主な作業

- `ElectricityBillSimulator` サービスを TDD で実装（全プランの料金計算・昇順ソート）

## 非自明な設計判断

- **sort_by は不安定**なため `[price, provider_id, plan_id]` の 3 段で決定的に並べる（同価格プランが floor 後に一致するケースがあり得る）
- **Float は明示的に弾く**: `Integer()` は Float を黙って切り捨てるため、`parse_integer!` で事前チェックする
- **`MAX_KWH = 9999`** は上限が確定するまでの暫定値（Issue #3 で質問中）

## PR スタック

PR #8 の上に積んでいる。PR #8 が `develop` にマージされれば本 PR の base も自動で切り替わる。

## 動作確認

- `bundle exec rspec` → 62 examples, 0 failures
- `bundle exec rubocop` → no offenses

Closes #6