### PR TITLE
電気料金シミュレーションサービスを実装

### DIFF
--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -38,7 +38,7 @@ class ElectricityBillSimulator
     [plan, (base + usage_price(plan)).floor.to_i]
   end
 
-  # 従量課金のみプラン (Looop) は基本料金 0、それ以外は ampere 一致レコードが無ければ nil
+  # 従量課金のみプランは基本料金 0、それ以外は ampere 一致レコードが無ければ nil
   def base_price(plan)
     return BigDecimal(0) if plan.metered_only?
 

--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -9,8 +9,8 @@ class ElectricityBillSimulator
   end
 
   def initialize(ampere:, kwh:)
-    @ampere = Integer(ampere)
-    @kwh = Integer(kwh)
+    @ampere = parse_integer!(ampere, :ampere)
+    @kwh = parse_integer!(kwh, :kwh)
 
     validate!
   end
@@ -23,6 +23,12 @@ class ElectricityBillSimulator
   end
 
   private
+
+  def parse_integer!(value, name)
+    raise ArgumentError, "#{name} must be an integer (got #{value.inspect})" if value.is_a?(Float)
+
+    Integer(value)
+  end
 
   def validate!
     unless VALID_AMPERES.include?(@ampere)

--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -2,6 +2,7 @@
 
 class ElectricityBillSimulator
   VALID_AMPERES = [10, 15, 20, 30, 40, 50, 60].freeze
+  MAX_KWH = 9999
 
   def self.call(ampere:, kwh:)
     new(ampere: ampere, kwh: kwh).call
@@ -27,7 +28,7 @@ class ElectricityBillSimulator
     unless VALID_AMPERES.include?(@ampere)
       raise ArgumentError, "ampere must be one of #{VALID_AMPERES} (got #{@ampere})"
     end
-    raise ArgumentError, "kwh must be greater than or equal to 0 (got #{@kwh})" if @kwh.negative?
+    raise ArgumentError, "kwh must be between 0 and #{MAX_KWH} (got #{@kwh})" unless (0..MAX_KWH).cover?(@kwh)
   end
 
   # アンペア非対応プランは nil を返し、filter_map で除外する

--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class ElectricityBillSimulator
+  VALID_AMPERES = [10, 15, 20, 30, 40, 50, 60].freeze
+
+  def self.call(ampere:, kwh:)
+    new(ampere: ampere, kwh: kwh).call
+  end
+
+  def initialize(ampere:, kwh:)
+    @ampere = Integer(ampere)
+    @kwh = Integer(kwh)
+
+    validate!
+  end
+
+  def call
+    Plan.all
+        .filter_map { |plan| pair_with_price(plan) }
+        .sort_by { |plan, price| [price, plan.provider_id, plan.id] }
+        .map { |plan, price| { provider_name: plan.provider.name, plan_name: plan.name, price: price } }
+  end
+
+  private
+
+  def validate!
+    unless VALID_AMPERES.include?(@ampere)
+      raise ArgumentError, "ampere must be one of #{VALID_AMPERES} (got #{@ampere})"
+    end
+    raise ArgumentError, "kwh must be greater than or equal to 0 (got #{@kwh})" if @kwh.negative?
+  end
+
+  # アンペア非対応プランは nil を返し、filter_map で除外する
+  def pair_with_price(plan)
+    base = base_price(plan)
+    return nil if base.nil?
+
+    [plan, (base + usage_price(plan)).floor.to_i]
+  end
+
+  # 従量課金のみプラン (Looop) は基本料金 0、それ以外は ampere 一致レコードが無ければ nil
+  def base_price(plan)
+    return BigDecimal(0) if plan.metered_only?
+
+    plan.ampere_based_rates.detect { |r| r.ampere == @ampere }&.rate
+  end
+
+  def usage_price(plan)
+    plan.usage_based_rates.sum(BigDecimal(0)) do |usage_rate|
+      usage_rate.rate * billable_kwh_for(usage_rate)
+    end
+  end
+
+  def billable_kwh_for(usage_rate)
+    upper = [@kwh, usage_rate.kilowatt_hour_high].min
+    consumed = upper - usage_rate.kilowatt_hour_low + 1
+
+    [consumed, 0].max
+  end
+end

--- a/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
+++ b/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe ElectricityBillSimulator do
       expect { described_class.call(ampere: 'abc', kwh: 400) }.to raise_error(StandardError)
     end
 
+    it 'float のアンペアで ArgumentError (丸めず弾く)' do
+      expect { described_class.call(ampere: 30.0, kwh: 400) }.to raise_error(ArgumentError, /ampere/)
+    end
+
+    it 'float の kWh で ArgumentError (丸めず弾く)' do
+      expect { described_class.call(ampere: 30, kwh: 400.5) }.to raise_error(ArgumentError, /kwh/)
+    end
+
     it 'Integer-coercible な文字列は正常に計算できる' do
       coerced = described_class.call(ampere: '30', kwh: '400')
       direct = described_class.call(ampere: 30, kwh: 400)

--- a/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
+++ b/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ElectricityBillSimulator do
+  subject(:result) { described_class.call(ampere: ampere, kwh: kwh) }
+
+  def price_for(plan_name, ampere:, kwh:)
+    described_class.call(ampere: ampere, kwh: kwh)
+                   .find { |row| row[:plan_name] == plan_name }[:price]
+  end
+
+  # 基本料金あり + 従量段階制（東京電力エナジーパートナー / 従量電灯B）
+  describe '基本料金あり + 従量段階制 (Plan id=1)' do
+    it '0kWh は基本料金のみ' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 0)).to eq 858
+    end
+
+    it '第1段階の上限 (120kWh)' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 120)).to eq 3243
+    end
+
+    it '第2段階の開始 (121kWh)' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 121)).to eq 3270
+    end
+
+    it '第2段階の上限 (300kWh)' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 300)).to eq 8010
+    end
+
+    it '第3段階の開始 (301kWh)' do
+      expect(price_for('従量電灯B', ampere: 30, kwh: 301)).to eq 8040
+    end
+
+    it '複数段階またがり (40A, 400kWh)' do
+      expect(price_for('従量電灯B', ampere: 40, kwh: 400)).to eq 11_353
+    end
+  end
+
+  # 基本料金なし + 従量均一（Looopでんき / おうちプラン）
+  describe '基本料金なし + 従量均一 (Plan id=4: Looop)' do
+    it '0kWh は 0 円' do
+      expect(price_for('おうちプラン', ampere: 30, kwh: 0)).to eq 0
+    end
+
+    it '通常使用 (400kWh)' do
+      expect(price_for('おうちプラン', ampere: 30, kwh: 400)).to eq 11_520
+    end
+  end
+
+  # アンペア非対応プランの除外（東京ガス / ずっとも電気1）
+  describe 'アンペア非対応プランの除外 (Plan id=3: ずっとも電気1)' do
+    let(:plan_names) { result.pluck(:plan_name) }
+
+    context 'when ampere=20A (ずっとも電気1 は非対応)' do
+      let(:ampere) { 20 }
+      let(:kwh) { 400 }
+
+      it 'ずっとも電気1 はレスポンスに含まれない' do
+        expect(plan_names).not_to include('ずっとも電気1')
+      end
+
+      it 'Looop おうちプランは含まれる (metered_only? は基本料金 0 で計算続行)' do
+        expect(plan_names).to include('おうちプラン')
+      end
+    end
+
+    context 'when ampere=30A (ずっとも電気1 は対応)' do
+      let(:ampere) { 30 }
+      let(:kwh) { 400 }
+
+      it 'ずっとも電気1 はレスポンスに含まれる' do
+        expect(plan_names).to include('ずっとも電気1')
+      end
+    end
+  end
+
+  describe '横断' do
+    let(:ampere) { 30 }
+    let(:kwh) { 400 }
+
+    it '全プラン対応のアンペアでは 4 プラン全て返る' do
+      expect(result.size).to eq 4
+    end
+
+    it 'price 昇順で並ぶ' do
+      prices = result.pluck(:price)
+      expect(prices).to eq prices.sort
+    end
+  end
+
+  describe '戻り値の形' do
+    let(:ampere) { 30 }
+    let(:kwh) { 400 }
+
+    it '各要素は :provider_name / :plan_name / :price の 3 キーのみを持つ' do
+      result.each do |row|
+        expect(row.keys).to contain_exactly(:provider_name, :plan_name, :price)
+      end
+    end
+
+    it ':price は Integer' do
+      result.each do |row|
+        expect(row[:price]).to be_a(Integer)
+      end
+    end
+  end
+
+  describe '入力バリデーション' do
+    it 'サポート外のアンペア (25A) で ArgumentError' do
+      expect { described_class.call(ampere: 25, kwh: 400) }.to raise_error(ArgumentError, /ampere/)
+    end
+
+    it '0A (集合外) で ArgumentError' do
+      expect { described_class.call(ampere: 0, kwh: 400) }.to raise_error(ArgumentError, /ampere/)
+    end
+
+    it '負の kWh で ArgumentError' do
+      expect { described_class.call(ampere: 30, kwh: -1) }.to raise_error(ArgumentError, /kwh/)
+    end
+
+    it 'Integer に coerce できないアンペアで例外' do
+      expect { described_class.call(ampere: 'abc', kwh: 400) }.to raise_error(StandardError)
+    end
+
+    it 'Integer-coercible な文字列は正常に計算できる' do
+      coerced = described_class.call(ampere: '30', kwh: '400')
+      direct = described_class.call(ampere: 30, kwh: 400)
+      expect(coerced).to eq direct
+    end
+  end
+end

--- a/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
+++ b/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
@@ -65,14 +65,6 @@ RSpec.describe ElectricityBillSimulator do
       end
     end
 
-    context 'when ampere=30A (ずっとも電気1 は対応)' do
-      let(:ampere) { 30 }
-      let(:kwh) { 400 }
-
-      it 'ずっとも電気1 はレスポンスに含まれる' do
-        expect(plan_names).to include('ずっとも電気1')
-      end
-    end
   end
 
   describe '横断' do

--- a/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
+++ b/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
@@ -119,6 +119,10 @@ RSpec.describe ElectricityBillSimulator do
       expect { described_class.call(ampere: 30, kwh: -1) }.to raise_error(ArgumentError, /kwh/)
     end
 
+    it 'MAX_KWH を超えた kwh で ArgumentError' do
+      expect { described_class.call(ampere: 30, kwh: 10_000) }.to raise_error(ArgumentError, /kwh/)
+    end
+
     it 'Integer に coerce できないアンペアで例外' do
       expect { described_class.call(ampere: 'abc', kwh: 400) }.to raise_error(StandardError)
     end


### PR DESCRIPTION
## 要約

Issue #6（`ElectricityBillSimulator.call(ampere:, kwh:)` の TDD 実装）を解決する。

- 全プランの料金計算・価格昇順ソート・戻り値整形を 1 クラスで実装
- テストを先に書いてから実装する TDD サイクルで進めた

Closes #6

## 実装してみて発生した追加判断

- **`sort_by` の不安定性に対応**: Ruby の `sort_by` は不安定ソートのため、同価格のプランが `floor` 後に一致した場合に順序が非決定的になる。`[price, provider_id, plan_id]` の 3 段 tiebreaker で決定的な並び順を保証した
- **Float を明示的に弾く**: `Integer()` は Float（例: `30.0`）を黙って切り捨てるため、事前チェックで `Float` 型を `ArgumentError` にした。「小数を整数として扱う」より「弾く」を選んだのは、呼び出し元（コントローラ）でリクエスト層の検証を済ませている前提のため

## テストケース一覧

### `spec/services/electricity_bill_simulator_spec.rb`（17 examples）

| カテゴリ | ケース | ampere | kwh | 期待 |
|---|---|---|---|---|
| 基本料金あり + 段階制（従量電灯B） | 0kWh は基本料金のみ | 30 | 0 | 858 |
| | 第1段階の上限（120kWh） | 30 | 120 | 3,243 |
| | 第2段階の開始（121kWh） | 30 | 121 | 3,270 |
| | 第2段階の上限（300kWh） | 30 | 300 | 8,010 |
| | 第3段階の開始（301kWh） | 30 | 301 | 8,040 |
| | 複数段階またがり | 40 | 400 | 11,353 |
| 基本料金なし + 均一（おうちプラン） | 0kWh は 0 円 | 30 | 0 | 0 |
| | 通常使用（400kWh） | 30 | 400 | 11,520 |
| アンペア非対応プランの除外 | 20A でずっとも電気1 が除外される | 20 | 400 | 含まれない |
| | 20A で Looop おうちプランは含まれる | 20 | 400 | 含まれる |
| 横断 | 全プラン対応 A で 4 プラン返る | 30 | 400 | 4件 |
| | price 昇順で並ぶ | 30 | 400 | ソート済み |
| 戻り値の形 | 各要素が 3 キーのみ持つ | 30 | 400 | keys 一致 |
| | price は Integer | 30 | 400 | Integer 型 |
| 入力バリデーション | サポート外アンペア (25A) で ArgumentError | — | — | raises |
| | Float アンペア (30.0) で ArgumentError | — | — | raises |
| | Float の kwh (400.5) で ArgumentError | — | — | raises |
| | 負の kwh で ArgumentError | — | — | raises |
| | MAX_KWH 超過で ArgumentError | — | — | raises |
| | Integer-coercible な文字列は正常計算 | — | — | 整数と同結果 |