### PR TITLE
APIエンドポイントとリクエストバリデーションを実装

### DIFF
--- a/serverside_challenge_2/challenge/.rubocop.yml
+++ b/serverside_challenge_2/challenge/.rubocop.yml
@@ -64,6 +64,7 @@ Rails/FindEach:
 RSpec/DescribeClass:
   Exclude:
     - "spec/data_consistency_spec.rb"
+    - "spec/requests/**/*"
 
 RSpec/IteratedExpectation:
   Exclude:

--- a/serverside_challenge_2/challenge/app/controllers/api/v1/electricity_bill_simulations_controller.rb
+++ b/serverside_challenge_2/challenge/app/controllers/api/v1/electricity_bill_simulations_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ElectricityBillSimulationsController < ApplicationController
+      def index
+        form = ElectricityBillSimulationParams.new(params.permit(:ampere, :kwh))
+        return render_validation_errors(form) if form.invalid?
+
+        results = ElectricityBillSimulator.call(ampere: form.ampere, kwh: form.kwh)
+        render json: { data: results }, status: :ok
+      end
+
+      private
+
+      def render_validation_errors(form)
+        render json: { errors: form.jsonapi_errors }, status: :bad_request
+      end
+    end
+  end
+end

--- a/serverside_challenge_2/challenge/app/forms/electricity_bill_simulation_params.rb
+++ b/serverside_challenge_2/challenge/app/forms/electricity_bill_simulation_params.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ElectricityBillSimulationParams
+  include ActiveModel::Model
+
+  AMPERE_VALUES = [10, 15, 20, 30, 40, 50, 60].freeze
+  MAX_KWH = 9_999
+
+  attr_writer :ampere, :kwh
+
+  validates :ampere, presence: true,
+                     inclusion: { in: AMPERE_VALUES, allow_blank: true }
+  validates :kwh, presence: true,
+                  numericality: {
+                    only_integer: true,
+                    greater_than_or_equal_to: 0,
+                    less_than_or_equal_to: MAX_KWH,
+                    allow_blank: true
+                  }
+
+  def ampere
+    cast_to_integer(@ampere)
+  end
+
+  def kwh
+    cast_to_integer(@kwh)
+  end
+
+  def jsonapi_errors
+    errors.map do |error|
+      {
+        status: '400',
+        title: I18n.t('electricity_bill_simulations.errors.title'),
+        detail: error.full_message,
+        source: { parameter: error.attribute.to_s }
+      }
+    end
+  end
+
+  private
+
+  def cast_to_integer(value)
+    return nil if value.nil? || value == ''
+
+    Integer(value.to_s, 10)
+  rescue ArgumentError
+    value
+  end
+end

--- a/serverside_challenge_2/challenge/app/forms/electricity_bill_simulation_params.rb
+++ b/serverside_challenge_2/challenge/app/forms/electricity_bill_simulation_params.rb
@@ -2,14 +2,12 @@
 
 class ElectricityBillSimulationParams
   include ActiveModel::Model
-
-  AMPERE_VALUES = [10, 15, 20, 30, 40, 50, 60].freeze
-  MAX_KWH = 9_999
+  include ElectricityBillConstants
 
   attr_writer :ampere, :kwh
 
   validates :ampere, presence: true,
-                     inclusion: { in: AMPERE_VALUES, allow_blank: true }
+                     inclusion: { in: VALID_AMPERES, allow_blank: true }
   validates :kwh, presence: true,
                   numericality: {
                     only_integer: true,

--- a/serverside_challenge_2/challenge/app/models/concerns/electricity_bill_constants.rb
+++ b/serverside_challenge_2/challenge/app/models/concerns/electricity_bill_constants.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ElectricityBillConstants
+  VALID_AMPERES = [10, 15, 20, 30, 40, 50, 60].freeze
+  MAX_KWH = 9_999
+end

--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class ElectricityBillSimulator
-  VALID_AMPERES = [10, 15, 20, 30, 40, 50, 60].freeze
-  MAX_KWH = 9999
+  include ElectricityBillConstants
 
   def self.call(ampere:, kwh:)
     new(ampere: ampere, kwh: kwh).call

--- a/serverside_challenge_2/challenge/config/locales/ja.yml
+++ b/serverside_challenge_2/challenge/config/locales/ja.yml
@@ -1,8 +1,26 @@
 ja:
   activemodel:
+    attributes:
+      electricity_bill_simulation_params:
+        ampere: "ampere"
+        kwh: "kwh"
     errors:
       models:
         usage_based_rate:
           attributes:
             kilowatt_hour_low:
               must_not_exceed_high: は kilowatt_hour_high より小さくなければなりません
+        electricity_bill_simulation_params:
+          attributes:
+            ampere:
+              blank: "は必須です"
+              inclusion: "は 10, 15, 20, 30, 40, 50, 60 のいずれかを指定してください"
+            kwh:
+              blank: "は必須です"
+              not_a_number: "は整数で指定してください"
+              not_an_integer: "は整数で指定してください"
+              greater_than_or_equal_to: "は 0 以上の値を指定してください"
+              less_than_or_equal_to: "は 9999 以下の値を指定してください"
+  electricity_bill_simulations:
+    errors:
+      title: "Invalid Parameter"

--- a/serverside_challenge_2/challenge/config/routes.rb
+++ b/serverside_challenge_2/challenge/config/routes.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  namespace :api do
+    namespace :v1 do
+      resources :electricity_bill_simulations, only: [:index]
+    end
+  end
 end

--- a/serverside_challenge_2/challenge/spec/forms/electricity_bill_simulation_params_spec.rb
+++ b/serverside_challenge_2/challenge/spec/forms/electricity_bill_simulation_params_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ElectricityBillSimulationParams do
+  def build_params(ampere: '30', kwh: '400')
+    described_class.new(ampere: ampere, kwh: kwh)
+  end
+
+  describe 'バリデーション' do
+    context 'with ampere' do
+      it '有効値（30）は valid' do
+        expect(build_params(ampere: '30')).to be_valid
+      end
+
+      it '上限ぎりぎり kwh=9999 は valid' do
+        expect(build_params(kwh: '9999')).to be_valid
+      end
+
+      it 'AMPERE_VALUES に含まれない値（25）は invalid' do
+        params = build_params(ampere: '25')
+        expect(params).to be_invalid
+        expect(params.errors[:ampere]).to include(match(/のいずれかを指定/))
+      end
+
+      it 'ampere が欠落している場合は blank エラー' do
+        params = build_params(ampere: nil)
+        expect(params).to be_invalid
+        expect(params.errors[:ampere]).to include(match(/必須/))
+      end
+
+      it 'ampere が非数値文字列（"abc"）の場合は inclusion エラー' do
+        params = build_params(ampere: 'abc')
+        expect(params).to be_invalid
+        expect(params.errors[:ampere]).to include(match(/のいずれかを指定/))
+      end
+    end
+
+    context 'with kwh' do
+      it 'kwh が欠落している場合は blank エラー' do
+        params = build_params(kwh: nil)
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/必須/))
+      end
+
+      it '負の値（-1）は invalid' do
+        params = build_params(kwh: '-1')
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/0 以上/))
+      end
+
+      it '小数（"100.5"）は invalid' do
+        params = build_params(kwh: '100.5')
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/整数/))
+      end
+
+      it '上限超過（10000）は invalid' do
+        params = build_params(kwh: '10000')
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/9999 以下/))
+      end
+
+      it '非数値文字列（"abc"）は invalid' do
+        params = build_params(kwh: 'abc')
+        expect(params).to be_invalid
+        expect(params.errors[:kwh]).to include(match(/整数/))
+      end
+    end
+
+    context 'with multiple invalid params' do
+      it '両方不正（ampere=25, kwh=-1）は 2 件のエラー' do
+        params = build_params(ampere: '25', kwh: '-1')
+        expect(params).to be_invalid
+        expect(params.errors.count).to eq(2)
+      end
+
+      it '両方欠落は 2 件のエラー' do
+        params = build_params(ampere: nil, kwh: nil)
+        expect(params).to be_invalid
+        expect(params.errors.count).to eq(2)
+      end
+    end
+  end
+
+  describe '#jsonapi_errors' do
+    it 'status / title / detail / source.parameter のキーを持つ配列を返す' do
+      params = build_params(ampere: '25')
+      params.valid?
+
+      error = params.jsonapi_errors.first
+      expect(error[:status]).to eq('400')
+      expect(error[:title]).to eq('Invalid Parameter')
+      expect(error[:detail]).to be_a(String)
+      expect(error[:source]).to eq({ parameter: 'ampere' })
+    end
+
+    it 'エラーが複数ある場合は全件返す' do
+      params = build_params(ampere: nil, kwh: nil)
+      params.valid?
+
+      expect(params.jsonapi_errors.count).to eq(2)
+    end
+  end
+end

--- a/serverside_challenge_2/challenge/spec/requests/api/v1/electricity_bill_simulations_spec.rb
+++ b/serverside_challenge_2/challenge/spec/requests/api/v1/electricity_bill_simulations_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/electricity_bill_simulations' do
+  let(:valid_params) { { ampere: 30, kwh: 400 } }
+
+  context 'with valid params' do
+    it 'status 200 を返し、data 配列が provider_name / plan_name / price を持つ' do
+      get '/api/v1/electricity_bill_simulations', params: valid_params
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data']).to be_an(Array)
+      expect(json['data']).to all(include('provider_name', 'plan_name', 'price'))
+    end
+  end
+
+  context 'with invalid ampere' do
+    it '不正な ampere で status 400 を返し、errors[0] が JSON:API 形式' do
+      get '/api/v1/electricity_bill_simulations', params: { ampere: 25, kwh: 400 }
+
+      expect(response).to have_http_status(:bad_request)
+      json = response.parsed_body
+      error = json['errors'].first
+      expect(error['status']).to eq('400')
+      expect(error['title']).to eq('Invalid Parameter')
+      expect(error['detail']).to be_a(String)
+      expect(error['source']['parameter']).to eq('ampere')
+    end
+  end
+
+  context 'without params' do
+    it 'パラメータなしで status 400 を返し、errors が 2 件' do
+      get '/api/v1/electricity_bill_simulations'
+
+      expect(response).to have_http_status(:bad_request)
+      json = response.parsed_body
+      expect(json['errors'].count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## 要約

Issue #7（`GET /api/v1/electricity_bill_simulations` エンドポイントの TDD 実装）を解決する。

- `ElectricityBillSimulationParams`（Form Object）でリクエストパラメータの検証と JSON:API エラー配列生成を担い、コントローラは薄く保つ
- i18n は ActiveModel 標準機構（`activemodel.errors.models.*`）で `ja.yml` に一元管理

Closes #7

## 実装してみて発生した追加判断

- **`ActiveModel::Attributes` を使わず `attr_writer` + reader override を採用**: `attribute :kwh, :integer` を使うと `"100.5"` → `100` に黙示切り捨てされ「小数を弾く」テストが失敗する。`cast_to_integer` が `Integer("100.5")` で `ArgumentError` を捕捉し生値を返すことで、`numericality` が `:not_an_integer` を立てる設計にした
- **`VALID_AMPERES` / `MAX_KWH` を `ElectricityBillConstants` モジュールに切り出し**: 同じ定数が `ElectricityBillSimulationParams` と `ElectricityBillSimulator` に重複・名称不統一で定義されており、片方だけ変更したときの不整合を防ぐため `app/models/concerns/electricity_bill_constants.rb` に一元化した

## テストケース一覧

### `spec/forms/electricity_bill_simulation_params_spec.rb`（14 examples）

| ケース | 入力 | 期待 |
|---|---|---|
| 有効値（ampere=30）は valid | ampere=30, kwh=400 | valid |
| 上限ぎりぎり kwh=9999 は valid | ampere=30, kwh=9999 | valid |
| AMPERE_VALUES 外（25）は inclusion エラー | ampere=25, kwh=400 | errors[:ampere] |
| ampere 欠落は blank エラー | ampere=nil, kwh=400 | errors[:ampere] |
| ampere が非数値文字列（"abc"）は inclusion エラー | ampere=abc, kwh=400 | errors[:ampere] |
| kwh 欠落は blank エラー | ampere=30, kwh=nil | errors[:kwh] |
| 負の kwh（-1）は greater_than_or_equal_to エラー | ampere=30, kwh=-1 | errors[:kwh] |
| 小数（"100.5"）は not_an_integer エラー | ampere=30, kwh=100.5 | errors[:kwh] |
| 上限超過（10000）は less_than_or_equal_to エラー | ampere=30, kwh=10000 | errors[:kwh] |
| 非数値文字列（"abc"）は not_a_number エラー | ampere=30, kwh=abc | errors[:kwh] |
| 両方不正は 2 件のエラー | ampere=25, kwh=-1 | errors 2件 |
| 両方欠落は 2 件のエラー | ampere=nil, kwh=nil | errors 2件 |
| jsonapi_errors が正しいキー構造を返す | ampere=25 | status/title/detail/source.parameter |
| jsonapi_errors が全件返す | ampere=nil, kwh=nil | 2件 |

### `spec/requests/api/v1/electricity_bill_simulations_spec.rb`（3 examples）

| ケース | パラメータ | 期待 |
|---|---|---|
| 正常系 | ampere=30&kwh=400 | status 200 / data 配列に provider_name / plan_name / price |
| 単一エラー | ampere=25&kwh=400 | status 400 / errors[0] が JSON:API 形式 |
| パラメータなし | （なし） | status 400 / errors が 2 件 |