### PR TITLE
ActiveHash/YAML から ActiveRecord/PostgreSQL へのDB移行

### DIFF
--- a/serverside_challenge_2/challenge/Gemfile
+++ b/serverside_challenge_2/challenge/Gemfile
@@ -11,9 +11,6 @@ gem 'rails', '~> 7.0.8'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 1.6.0', '< 2.0'
 
-# Read-only models backed by YAML/JSON files (used for plan / rate master data)
-gem 'active_hash', '~> 3.3'
-
 # Rails / ActiveModel / ActiveRecord 標準メッセージの ja 翻訳を提供する
 gem 'rails-i18n', '~> 7.0'
 

--- a/serverside_challenge_2/challenge/Gemfile.lock
+++ b/serverside_challenge_2/challenge/Gemfile.lock
@@ -46,8 +46,6 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    active_hash (3.3.1)
-      activesupport (>= 5.0.0)
     activejob (7.0.8)
       activesupport (= 7.0.8)
       globalid (>= 0.3.6)
@@ -239,7 +237,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  active_hash (~> 3.3)
   bootsnap
   debug
   factory_bot_rails (~> 6.4)

--- a/serverside_challenge_2/challenge/README.md
+++ b/serverside_challenge_2/challenge/README.md
@@ -21,8 +21,11 @@ docker compose up -d db
 # DB 作成 (development / test)
 docker compose run --rm web bin/rails db:create
 
-# マイグレーション (まだ存在しないが今後の運用用)
+# マイグレーション
 docker compose run --rm web bin/rails db:migrate
+
+# マスタデータ投入 (providers / plans / rates)
+docker compose run --rm web bin/rails db:seed
 ```
 
 ## 開発サーバー

--- a/serverside_challenge_2/challenge/app/models/ampere_based_rate.rb
+++ b/serverside_challenge_2/challenge/app/models/ampere_based_rate.rb
@@ -1,46 +1,8 @@
 # frozen_string_literal: true
 
-class AmpereBasedRate < ActiveYaml::Base
-  include ActiveHash::Associations
-  include ActiveModel::Validations
-
-  fields :plan_id, :ampere, :rate
-
+class AmpereBasedRate < ApplicationRecord
   belongs_to :plan
 
-  validates :plan_id, presence: true
-  validates :plan_id, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
-  validates :ampere, inclusion: { in: [10, 15, 20, 30, 40, 50, 60] }
-  validates :rate, presence: true
-  validate :rate_must_be_number
-
-  # 浮動小数点誤差を避けるため BigDecimal を返す（YAML 上は文字列で記述）
-  def rate
-    value = attributes[:rate]
-    return nil if value.nil?
-
-    value.is_a?(BigDecimal) ? value : BigDecimal(value.to_s)
-  end
-
-  # rate getter は BigDecimal 変換時に ArgumentError を投げ得るため、
-  # バリデーション時は raw 値を直接読むようにする（presence などが getter を呼んで落ちるのを回避）
-  def read_attribute_for_validation(key)
-    return attributes[:rate] if key.to_sym == :rate
-
-    super
-  end
-
-  private
-
-  # rate getter は BigDecimal 変換時に ArgumentError を投げ得るため、
-  # numericality ではなく raw 値を直接読む custom validator で型・範囲を検証する
-  def rate_must_be_number
-    value = attributes[:rate]
-    return if value.nil?
-
-    decimal = BigDecimal(value.to_s)
-    errors.add(:rate, :greater_than_or_equal_to, count: 0) if decimal.negative?
-  rescue ArgumentError
-    errors.add(:rate, :not_a_number)
-  end
+  validates :ampere, presence: true, inclusion: { in: [10, 15, 20, 30, 40, 50, 60] }
+  validates :rate, presence: true, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/serverside_challenge_2/challenge/app/models/plan.rb
+++ b/serverside_challenge_2/challenge/app/models/plan.rb
@@ -1,20 +1,12 @@
 # frozen_string_literal: true
 
-class Plan < ActiveYaml::Base
-  include ActiveHash::Associations
-  include ActiveModel::Validations
-
-  fields :name, :provider_id
-
+class Plan < ApplicationRecord
   belongs_to :provider
-  has_many :ampere_based_rates
-  has_many :usage_based_rates
+  has_many :ampere_based_rates, dependent: :destroy
+  has_many :usage_based_rates, dependent: :destroy
 
-  validates :name, :provider_id, presence: true
-  validates :provider_id, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :name, presence: true
 
-  # ampere_based_rates レコードの有無で従量課金のみプランを判定する
-  # （フラグを別途持たせるとレコード有無と矛盾し得るため、レコード有無を単一の真実とする）
   def metered_only?
     ampere_based_rates.empty?
   end

--- a/serverside_challenge_2/challenge/app/models/provider.rb
+++ b/serverside_challenge_2/challenge/app/models/provider.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
-class Provider < ActiveYaml::Base
-  include ActiveHash::Associations
-  include ActiveModel::Validations
-
-  fields :name
-
-  has_many :plans
+class Provider < ApplicationRecord
+  has_many :plans, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/serverside_challenge_2/challenge/app/models/usage_based_rate.rb
+++ b/serverside_challenge_2/challenge/app/models/usage_based_rate.rb
@@ -1,38 +1,12 @@
 # frozen_string_literal: true
 
-class UsageBasedRate < ActiveYaml::Base
-  include ActiveHash::Associations
-  include ActiveModel::Validations
-
-  fields :plan_id, :kilowatt_hour_low, :kilowatt_hour_high, :rate
-
+class UsageBasedRate < ApplicationRecord
   belongs_to :plan
 
-  validates :plan_id, :kilowatt_hour_low, :kilowatt_hour_high, :rate, presence: true
-  validates :plan_id,
-            numericality: { only_integer: true, greater_than: 0 },
-            allow_nil: true
-  validates :kilowatt_hour_low, :kilowatt_hour_high,
-            numericality: { only_integer: true, greater_than: 0 },
-            allow_nil: true
+  validates :kilowatt_hour_low, :kilowatt_hour_high, presence: true,
+            numericality: { only_integer: true, greater_than: 0 }
+  validates :rate, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validate :low_must_not_exceed_high
-  validate :rate_must_be_number
-
-  # 浮動小数点誤差を避けるため BigDecimal を返す（YAML 上は文字列で記述）
-  def rate
-    value = attributes[:rate]
-    return nil if value.nil?
-
-    value.is_a?(BigDecimal) ? value : BigDecimal(value.to_s)
-  end
-
-  # rate getter は BigDecimal 変換時に ArgumentError を投げ得るため、
-  # バリデーション時は raw 値を直接読むようにする（presence などが getter を呼んで落ちるのを回避）
-  def read_attribute_for_validation(key)
-    return attributes[:rate] if key.to_sym == :rate
-
-    super
-  end
 
   private
 
@@ -41,17 +15,5 @@ class UsageBasedRate < ActiveYaml::Base
     return unless kilowatt_hour_low >= kilowatt_hour_high
 
     errors.add(:kilowatt_hour_low, :must_not_exceed_high)
-  end
-
-  # rate getter は BigDecimal 変換時に ArgumentError を投げ得るため、
-  # numericality ではなく raw 値を直接読む custom validator で型・範囲を検証する
-  def rate_must_be_number
-    value = attributes[:rate]
-    return if value.nil?
-
-    decimal = BigDecimal(value.to_s)
-    errors.add(:rate, :greater_than_or_equal_to, count: 0) if decimal.negative?
-  rescue ArgumentError
-    errors.add(:rate, :not_a_number)
   end
 end

--- a/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
+++ b/serverside_challenge_2/challenge/app/services/electricity_bill_simulator.rb
@@ -15,7 +15,7 @@ class ElectricityBillSimulator
   end
 
   def call
-    Plan.all
+    Plan.includes(:provider, :ampere_based_rates, :usage_based_rates)
         .filter_map { |plan| pair_with_price(plan) }
         .sort_by { |plan, price| [price, plan.provider_id, plan.id] }
         .map { |plan, price| { provider_name: plan.provider.name, plan_name: plan.name, price: price } }

--- a/serverside_challenge_2/challenge/config/initializers/active_hash.rb
+++ b/serverside_challenge_2/challenge/config/initializers/active_hash.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-ActiveFile::Base.set_root_path Rails.root.join('db/data').to_s

--- a/serverside_challenge_2/challenge/config/locales/ja.yml
+++ b/serverside_challenge_2/challenge/config/locales/ja.yml
@@ -6,10 +6,6 @@ ja:
         kwh: "kwh"
     errors:
       models:
-        usage_based_rate:
-          attributes:
-            kilowatt_hour_low:
-              must_not_exceed_high: は kilowatt_hour_high より小さくなければなりません
         electricity_bill_simulation_params:
           attributes:
             ampere:
@@ -21,6 +17,13 @@ ja:
               not_an_integer: "は整数で指定してください"
               greater_than_or_equal_to: "は 0 以上の値を指定してください"
               less_than_or_equal_to: "は 9999 以下の値を指定してください"
+  activerecord:
+    errors:
+      models:
+        usage_based_rate:
+          attributes:
+            kilowatt_hour_low:
+              must_not_exceed_high: は kilowatt_hour_high より小さくなければなりません
   electricity_bill_simulations:
     errors:
       title: "Invalid Parameter"

--- a/serverside_challenge_2/challenge/db/migrate/20260507000000_create_master_tables.rb
+++ b/serverside_challenge_2/challenge/db/migrate/20260507000000_create_master_tables.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class CreateMasterTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :providers do |t|
+      t.string :name, null: false
+      t.timestamps
+
+      t.index :name, unique: true
+    end
+
+    create_table :plans do |t|
+      t.references :provider, null: false, foreign_key: true
+      t.string :name, null: false
+      t.timestamps
+
+      t.index [:provider_id, :name], unique: true
+    end
+
+    create_table :ampere_based_rates do |t|
+      t.references :plan, null: false, foreign_key: true
+      t.integer :ampere, null: false
+      t.decimal :rate, precision: 10, scale: 2, null: false
+      t.timestamps
+
+      t.index [:plan_id, :ampere], unique: true
+      t.check_constraint 'rate >= 0', name: 'ampere_based_rates_rate_non_negative'
+      t.check_constraint 'ampere IN (10, 15, 20, 30, 40, 50, 60)', name: 'ampere_based_rates_ampere_allowed'
+    end
+
+    create_table :usage_based_rates do |t|
+      t.references :plan, null: false, foreign_key: true
+      t.integer :kilowatt_hour_low, null: false
+      t.integer :kilowatt_hour_high, null: false
+      t.decimal :rate, precision: 10, scale: 2, null: false
+      t.timestamps
+
+      t.index [:plan_id, :kilowatt_hour_low, :kilowatt_hour_high], unique: true,
+              name: 'index_usage_based_rates_on_plan_and_range'
+      t.check_constraint 'rate >= 0', name: 'usage_based_rates_rate_non_negative'
+      t.check_constraint 'kilowatt_hour_low > 0', name: 'usage_based_rates_low_positive'
+      t.check_constraint 'kilowatt_hour_low <= kilowatt_hour_high', name: 'usage_based_rates_low_le_high'
+    end
+  end
+end

--- a/serverside_challenge_2/challenge/db/schema.rb
+++ b/serverside_challenge_2/challenge/db/schema.rb
@@ -1,0 +1,62 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2026_05_07_000000) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "ampere_based_rates", force: :cascade do |t|
+    t.bigint "plan_id", null: false
+    t.integer "ampere", null: false
+    t.decimal "rate", precision: 10, scale: 2, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["plan_id", "ampere"], name: "index_ampere_based_rates_on_plan_id_and_ampere", unique: true
+    t.index ["plan_id"], name: "index_ampere_based_rates_on_plan_id"
+    t.check_constraint "ampere = ANY (ARRAY[10, 15, 20, 30, 40, 50, 60])", name: "ampere_based_rates_ampere_allowed"
+    t.check_constraint "rate >= 0::numeric", name: "ampere_based_rates_rate_non_negative"
+  end
+
+  create_table "plans", force: :cascade do |t|
+    t.bigint "provider_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider_id", "name"], name: "index_plans_on_provider_id_and_name", unique: true
+    t.index ["provider_id"], name: "index_plans_on_provider_id"
+  end
+
+  create_table "providers", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_providers_on_name", unique: true
+  end
+
+  create_table "usage_based_rates", force: :cascade do |t|
+    t.bigint "plan_id", null: false
+    t.integer "kilowatt_hour_low", null: false
+    t.integer "kilowatt_hour_high", null: false
+    t.decimal "rate", precision: 10, scale: 2, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["plan_id", "kilowatt_hour_low", "kilowatt_hour_high"], name: "index_usage_based_rates_on_plan_and_range", unique: true
+    t.index ["plan_id"], name: "index_usage_based_rates_on_plan_id"
+    t.check_constraint "kilowatt_hour_low <= kilowatt_hour_high", name: "usage_based_rates_low_le_high"
+    t.check_constraint "kilowatt_hour_low > 0", name: "usage_based_rates_low_positive"
+    t.check_constraint "rate >= 0::numeric", name: "usage_based_rates_rate_non_negative"
+  end
+
+  add_foreign_key "ampere_based_rates", "plans"
+  add_foreign_key "plans", "providers"
+  add_foreign_key "usage_based_rates", "plans"
+end

--- a/serverside_challenge_2/challenge/db/seeds.rb
+++ b/serverside_challenge_2/challenge/db/seeds.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+def upsert!(model, filename, attribute_keys)
+  YAML.load_file(Rails.root.join('db/data', filename)).each do |attrs|
+    record = model.find_or_initialize_by(id: attrs['id'])
+    record.assign_attributes(attrs.slice(*attribute_keys.map(&:to_s)))
+    record.save!
+  end
+end
+
+upsert!(Provider, 'providers.yml', %i[name])
+upsert!(Plan, 'plans.yml', %i[name provider_id])
+upsert!(AmpereBasedRate, 'ampere_based_rates.yml', %i[plan_id ampere rate])
+upsert!(UsageBasedRate, 'usage_based_rates.yml', %i[plan_id kilowatt_hour_low kilowatt_hour_high rate])
+
+[Provider, Plan, AmpereBasedRate, UsageBasedRate].each do |model|
+  max_id = model.maximum(:id).to_i
+  next if max_id.zero?
+
+  ActiveRecord::Base.connection.execute(
+    "SELECT setval(pg_get_serial_sequence('#{model.table_name}', 'id'), #{max_id})"
+  )
+end

--- a/serverside_challenge_2/challenge/db/seeds.rb
+++ b/serverside_challenge_2/challenge/db/seeds.rb
@@ -1,23 +1,35 @@
 # frozen_string_literal: true
 
-def upsert!(model, filename, attribute_keys)
-  YAML.load_file(Rails.root.join('db/data', filename)).each do |attrs|
-    record = model.find_or_initialize_by(id: attrs['id'])
-    record.assign_attributes(attrs.slice(*attribute_keys.map(&:to_s)))
-    record.save!
-  end
+seed_config = [
+  { model: Provider,        file: 'providers.yml',          keys: %i[name] },
+  { model: Plan,            file: 'plans.yml',              keys: %i[name provider_id] },
+  { model: AmpereBasedRate, file: 'ampere_based_rates.yml', keys: %i[plan_id ampere rate] },
+  { model: UsageBasedRate,  file: 'usage_based_rates.yml',
+    keys: %i[plan_id kilowatt_hour_low kilowatt_hour_high rate] }
+].freeze
+
+seed_data = seed_config.map do |config|
+  config.merge(records: YAML.load_file(Rails.root.join('db/data', config[:file])))
 end
 
-upsert!(Provider, 'providers.yml', %i[name])
-upsert!(Plan, 'plans.yml', %i[name provider_id])
-upsert!(AmpereBasedRate, 'ampere_based_rates.yml', %i[plan_id ampere rate])
-upsert!(UsageBasedRate, 'usage_based_rates.yml', %i[plan_id kilowatt_hour_low kilowatt_hour_high rate])
+ActiveRecord::Base.transaction do
+  seed_data.reverse_each do |config|
+    ids_in_yaml = config[:records].pluck('id')
+    config[:model].where.not(id: ids_in_yaml).destroy_all
+  end
 
-[Provider, Plan, AmpereBasedRate, UsageBasedRate].each do |model|
-  max_id = model.maximum(:id).to_i
-  next if max_id.zero?
+  seed_data.each do |config|
+    config[:records].each do |attrs|
+      record = config[:model].find_or_initialize_by(id: attrs['id'])
+      record.assign_attributes(attrs.slice(*config[:keys].map(&:to_s)))
+      record.save!
+    end
 
-  ActiveRecord::Base.connection.execute(
-    "SELECT setval(pg_get_serial_sequence('#{model.table_name}', 'id'), #{max_id})"
-  )
+    max_id = config[:model].maximum(:id).to_i
+    next if max_id.zero?
+
+    ActiveRecord::Base.connection.execute(
+      "SELECT setval(pg_get_serial_sequence('#{config[:model].table_name}', 'id'), #{max_id})"
+    )
+  end
 end

--- a/serverside_challenge_2/challenge/spec/data_consistency_spec.rb
+++ b/serverside_challenge_2/challenge/spec/data_consistency_spec.rb
@@ -2,18 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe 'YAMLデータ整合性' do
-  [Provider, Plan, AmpereBasedRate, UsageBasedRate].each do |model|
-    it "#{model.name} の全レコードが valid であること" do
-      model.all.each do |record|
-        # 第2引数のメッセージは expect 呼び出し前に評価されるため、
-        # 先に valid? を呼んで errors を確定させてから組み立てる
-        record.valid?
-        expect(record).to be_valid,
-                          "#{model.name}##{record.id}: #{record.errors.full_messages.join(', ')}"
-      end
-    end
-  end
+RSpec.describe 'シードデータの整合性' do
+  before { Rails.application.load_seed }
 
   describe 'プラン数' do
     it 'Plan は 4 件存在する' do
@@ -21,43 +11,13 @@ RSpec.describe 'YAMLデータ整合性' do
     end
   end
 
-  describe '参照整合性' do
-    it 'すべての Plan#provider_id が Provider に存在する' do
-      provider_ids = Provider.all.map(&:id)
-      Plan.all.each do |plan|
-        expect(provider_ids).to include(plan.provider_id),
-                                "Plan##{plan.id} が参照する provider_id=#{plan.provider_id} は存在しない"
-      end
-    end
-
-    it 'すべての AmpereBasedRate#plan_id が Plan に存在する' do
-      plan_ids = Plan.all.map(&:id)
-      AmpereBasedRate.all.each do |rate|
-        expect(plan_ids).to include(rate.plan_id)
-      end
-    end
-
-    it 'すべての UsageBasedRate#plan_id が Plan に存在する' do
-      plan_ids = Plan.all.map(&:id)
-      UsageBasedRate.all.each do |rate|
-        expect(plan_ids).to include(rate.plan_id)
-      end
-    end
-  end
-
-  describe '業務的不変条件' do
-    it 'metered_only? が true なのは Looopでんきおうちプラン (id=4) のみである' do
-      metered_only_ids = Plan.all.select(&:metered_only?).map(&:id)
-      expect(metered_only_ids).to eq [4]
-    end
-  end
-
-  describe 'rate の型保証' do
-    it '全レコードの rate が BigDecimal を返す' do
-      [AmpereBasedRate, UsageBasedRate].each do |model|
+  describe 'モデルバリデーション' do
+    [Provider, Plan, AmpereBasedRate, UsageBasedRate].each do |model|
+      it "#{model.name} の全レコードが valid であること" do
         model.all.each do |record|
-          expect(record.rate).to be_a(BigDecimal),
-                                 "#{model.name}##{record.id} の rate: #{record.rate.class}"
+          record.valid?
+          expect(record).to be_valid,
+                            "#{model.name}##{record.id}: #{record.errors.full_messages.join(', ')}"
         end
       end
     end
@@ -65,8 +25,8 @@ RSpec.describe 'YAMLデータ整合性' do
 
   describe '料金レンジの連続性' do
     it '各プランの usage_based_rates の最初の段は low=1 から始まる' do
-      Plan.all.each do |plan|
-        sorted = plan.usage_based_rates.sort_by(&:kilowatt_hour_low)
+      Plan.find_each do |plan|
+        sorted = plan.usage_based_rates.order(:kilowatt_hour_low)
         next if sorted.empty?
 
         first_low = sorted.first.kilowatt_hour_low
@@ -75,15 +35,19 @@ RSpec.describe 'YAMLデータ整合性' do
     end
 
     it '各プランの usage_based_rates は段の間に穴も重複もなく連続している' do
-      Plan.all.each do |plan|
-        sorted = plan.usage_based_rates.sort_by(&:kilowatt_hour_low)
-        sorted.each_cons(2) do |prev_seg, next_seg|
-          expected = prev_seg.kilowatt_hour_high + 1
-          actual = next_seg.kilowatt_hour_low
-          expect(actual).to eq(expected),
-                            "Plan##{plan.id}: 段の間に穴/重複あり (#{prev_seg.kilowatt_hour_high} → #{actual})"
+      Plan.find_each do |plan|
+        ranges = plan.usage_based_rates.order(:kilowatt_hour_low).pluck(:kilowatt_hour_low, :kilowatt_hour_high)
+        ranges.each_cons(2) do |(_, prev_high), (next_low, _)|
+          expect(next_low).to eq(prev_high + 1)
         end
       end
+    end
+  end
+
+  describe '業務的不変条件' do
+    it 'metered_only? なプランは Looopでんきおうちプラン (id=4) のみ' do
+      metered_only = Plan.all.select(&:metered_only?)
+      expect(metered_only.map(&:name)).to eq(['おうちプラン'])
     end
   end
 end

--- a/serverside_challenge_2/challenge/spec/factories/ampere_based_rates.rb
+++ b/serverside_challenge_2/challenge/spec/factories/ampere_based_rates.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :ampere_based_rate do
+    association :plan
+    ampere { 30 }
+    rate { '858.00' }
+  end
+end

--- a/serverside_challenge_2/challenge/spec/factories/ampere_based_rates.rb
+++ b/serverside_challenge_2/challenge/spec/factories/ampere_based_rates.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :ampere_based_rate do
     association :plan
-    ampere { 30 }
+    sequence(:ampere) { |n| [10, 15, 20, 30, 40, 50, 60][n % 7] }
     rate { '858.00' }
   end
 end

--- a/serverside_challenge_2/challenge/spec/factories/plans.rb
+++ b/serverside_challenge_2/challenge/spec/factories/plans.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :plan do
+    association :provider
+    sequence(:name) { |n| "プラン#{n}" }
+  end
+end

--- a/serverside_challenge_2/challenge/spec/factories/providers.rb
+++ b/serverside_challenge_2/challenge/spec/factories/providers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :provider do
+    sequence(:name) { |n| "電力会社#{n}" }
+  end
+end

--- a/serverside_challenge_2/challenge/spec/factories/usage_based_rates.rb
+++ b/serverside_challenge_2/challenge/spec/factories/usage_based_rates.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :usage_based_rate do
+    association :plan
+    kilowatt_hour_low { 1 }
+    kilowatt_hour_high { 9999 }
+    rate { '19.88' }
+  end
+end

--- a/serverside_challenge_2/challenge/spec/factories/usage_based_rates.rb
+++ b/serverside_challenge_2/challenge/spec/factories/usage_based_rates.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :usage_based_rate do
     association :plan
-    kilowatt_hour_low { 1 }
-    kilowatt_hour_high { 9999 }
+    sequence(:kilowatt_hour_low)  { |n| (n - 1) * 100 + 1 }
+    sequence(:kilowatt_hour_high) { |n| n * 100 }
     rate { '19.88' }
   end
 end

--- a/serverside_challenge_2/challenge/spec/models/ampere_based_rate_spec.rb
+++ b/serverside_challenge_2/challenge/spec/models/ampere_based_rate_spec.rb
@@ -5,37 +5,25 @@ require 'rails_helper'
 RSpec.describe AmpereBasedRate do
   describe 'バリデーション' do
     it 'ampere が許容アンペア数以外だと invalid になる' do
-      record = described_class.new(id: 999, plan_id: 1, ampere: 25, rate: '100')
+      record = build(:ampere_based_rate, ampere: 25)
       expect(record).not_to be_valid
       expect(record.errors[:ampere]).to be_present
     end
 
-    it 'plan_id が空だと invalid になる' do
-      record = described_class.new(id: 999, plan_id: nil, ampere: 30, rate: '100')
+    it 'plan が nil だと invalid になる' do
+      record = build(:ampere_based_rate, plan: nil)
       expect(record).not_to be_valid
-      expect(record.errors[:plan_id]).to be_present
+      expect(record.errors[:plan]).to be_present
     end
 
     it 'rate が空だと invalid になる' do
-      record = described_class.new(id: 999, plan_id: 1, ampere: 30, rate: nil)
-      expect(record).not_to be_valid
-      expect(record.errors[:rate]).to be_present
-    end
-
-    it 'plan_id が 0 以下だと invalid になる' do
-      record = described_class.new(id: 999, plan_id: 0, ampere: 30, rate: '100')
-      expect(record).not_to be_valid
-      expect(record.errors[:plan_id]).to be_present
-    end
-
-    it 'rate が数値変換できない文字列だと invalid になる' do
-      record = described_class.new(id: 999, plan_id: 1, ampere: 30, rate: 'abc')
+      record = build(:ampere_based_rate, rate: nil)
       expect(record).not_to be_valid
       expect(record.errors[:rate]).to be_present
     end
 
     it 'rate が負の数だと invalid になる' do
-      record = described_class.new(id: 999, plan_id: 1, ampere: 30, rate: '-100')
+      record = build(:ampere_based_rate, rate: -100)
       expect(record).not_to be_valid
       expect(record.errors[:rate]).to be_present
     end
@@ -43,12 +31,12 @@ RSpec.describe AmpereBasedRate do
 
   describe '#rate' do
     it 'BigDecimal を返す' do
-      record = described_class.new(id: 9999, plan_id: 1, ampere: 30, rate: '100.50')
+      record = create(:ampere_based_rate, rate: '100.50')
       expect(record.rate).to be_a(BigDecimal)
     end
 
     it '文字列を精度を保って BigDecimal に変換する' do
-      record = described_class.new(id: 9999, plan_id: 1, ampere: 30, rate: '286.00')
+      record = create(:ampere_based_rate, rate: '286.00')
       expect(record.rate).to eq BigDecimal('286.00')
     end
   end

--- a/serverside_challenge_2/challenge/spec/models/plan_spec.rb
+++ b/serverside_challenge_2/challenge/spec/models/plan_spec.rb
@@ -5,55 +5,45 @@ require 'rails_helper'
 RSpec.describe Plan do
   describe 'バリデーション' do
     it 'name が空だと invalid になる' do
-      record = described_class.new(id: 999, name: nil, provider_id: 1)
+      record = build(:plan, name: nil)
       expect(record).not_to be_valid
       expect(record.errors[:name]).to be_present
     end
 
-    it 'provider_id が空だと invalid になる' do
-      record = described_class.new(id: 999, name: 'foo', provider_id: nil)
+    it 'provider が nil だと invalid になる' do
+      record = build(:plan, provider: nil)
       expect(record).not_to be_valid
-      expect(record.errors[:provider_id]).to be_present
-    end
-
-    it 'provider_id が 0 以下だと invalid になる' do
-      record = described_class.new(id: 999, name: 'foo', provider_id: 0)
-      expect(record).not_to be_valid
-      expect(record.errors[:provider_id]).to be_present
-    end
-
-    it 'provider_id が文字列だと invalid になる' do
-      record = described_class.new(id: 999, name: 'foo', provider_id: 'abc')
-      expect(record).not_to be_valid
-      expect(record.errors[:provider_id]).to be_present
+      expect(record.errors[:provider]).to be_present
     end
   end
 
   describe 'アソシエーション' do
-    it 'belongs_to :provider が Provider を返す' do
-      plan = described_class.all.find { |p| p.provider_id.present? }
+    let(:plan) { create(:plan) }
+
+    it 'belongs_to :provider が引ける' do
       expect(plan.provider).to be_a(Provider)
     end
 
-    it 'has_many :ampere_based_rates が AmpereBasedRate の配列を返す' do
-      plan = described_class.all.find { |p| p.ampere_based_rates.any? }
-      expect(plan.ampere_based_rates).to all(be_a(AmpereBasedRate))
+    it 'has_many :ampere_based_rates が引ける' do
+      create_list(:ampere_based_rate, 3, plan: plan)
+      expect(plan.ampere_based_rates.size).to eq 3
     end
 
-    it 'has_many :usage_based_rates が UsageBasedRate の配列を返す' do
-      plan = described_class.all.find { |p| p.usage_based_rates.any? }
-      expect(plan.usage_based_rates).to all(be_a(UsageBasedRate))
+    it 'has_many :usage_based_rates が引ける' do
+      create_list(:usage_based_rate, 2, plan: plan)
+      expect(plan.usage_based_rates.size).to eq 2
     end
   end
 
   describe '#metered_only?' do
-    it 'ampere_based_rates が存在しないプランは true を返す' do
-      plan = described_class.new(id: 9999, name: 'テスト', provider_id: 1)
+    it 'ampere_based_rates が存在しない場合に true を返す' do
+      plan = create(:plan)
       expect(plan.metered_only?).to be true
     end
 
-    it 'ampere_based_rates が存在するプランは false を返す' do
-      plan = described_class.all.find { |p| p.ampere_based_rates.any? }
+    it 'ampere_based_rates が存在する場合は false を返す' do
+      plan = create(:plan)
+      create(:ampere_based_rate, plan: plan)
       expect(plan.metered_only?).to be false
     end
   end

--- a/serverside_challenge_2/challenge/spec/models/provider_spec.rb
+++ b/serverside_challenge_2/challenge/spec/models/provider_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Provider do
   describe 'バリデーション' do
     it 'name が空だと invalid になる' do
-      record = described_class.new(id: 999, name: nil)
+      record = build(:provider, name: nil)
       expect(record).not_to be_valid
       expect(record.errors[:name]).to be_present
     end
@@ -13,8 +13,9 @@ RSpec.describe Provider do
 
   describe 'アソシエーション' do
     it 'has_many :plans が引ける' do
-      provider = described_class.find(1)
-      expect(provider.plans.map(&:id)).to contain_exactly(1, 2)
+      provider = create(:provider)
+      create_list(:plan, 2, provider: provider)
+      expect(provider.plans.size).to eq 2
     end
   end
 end

--- a/serverside_challenge_2/challenge/spec/models/usage_based_rate_spec.rb
+++ b/serverside_challenge_2/challenge/spec/models/usage_based_rate_spec.rb
@@ -4,19 +4,17 @@ require 'rails_helper'
 
 RSpec.describe UsageBasedRate do
   describe 'バリデーション' do
-    it 'plan_id / kilowatt_hour_low / kilowatt_hour_high / rate が空だと invalid になる' do
-      record = described_class.new(id: 999)
+    it 'plan / kilowatt_hour_low / kilowatt_hour_high / rate が空だと invalid になる' do
+      record = build(:usage_based_rate, plan: nil, kilowatt_hour_low: nil, kilowatt_hour_high: nil, rate: nil)
       expect(record).not_to be_valid
-      expect(record.errors[:plan_id]).to be_present
+      expect(record.errors[:plan]).to be_present
       expect(record.errors[:kilowatt_hour_low]).to be_present
       expect(record.errors[:kilowatt_hour_high]).to be_present
       expect(record.errors[:rate]).to be_present
     end
 
     it 'kilowatt_hour_low が kilowatt_hour_high を超えると invalid になる' do
-      record = described_class.new(
-        id: 999, plan_id: 1, kilowatt_hour_low: 200, kilowatt_hour_high: 100, rate: '10'
-      )
+      record = build(:usage_based_rate, kilowatt_hour_low: 200, kilowatt_hour_high: 100)
       expect(record).not_to be_valid
       expect(record.errors[:kilowatt_hour_low]).to be_present
     end
@@ -30,41 +28,25 @@ RSpec.describe UsageBasedRate do
     end
 
     it 'low > high のエラーメッセージが日本語で返る' do
-      record = described_class.new(
-        id: 999, plan_id: 1, kilowatt_hour_low: 200, kilowatt_hour_high: 100, rate: '10'
-      )
+      record = build(:usage_based_rate, kilowatt_hour_low: 200, kilowatt_hour_high: 100)
       record.valid?
       expect(record.errors[:kilowatt_hour_low]).to include('は kilowatt_hour_high より小さくなければなりません')
     end
 
     it 'kilowatt_hour_low が 0 以下だと invalid になる' do
-      record = described_class.new(
-        id: 999, plan_id: 1, kilowatt_hour_low: 0, kilowatt_hour_high: 100, rate: '10'
-      )
+      record = build(:usage_based_rate, kilowatt_hour_low: 0)
       expect(record).not_to be_valid
       expect(record.errors[:kilowatt_hour_low]).to be_present
     end
 
     it 'kilowatt_hour_high が 0 以下だと invalid になる' do
-      record = described_class.new(
-        id: 999, plan_id: 1, kilowatt_hour_low: 1, kilowatt_hour_high: 0, rate: '10'
-      )
+      record = build(:usage_based_rate, kilowatt_hour_low: 1, kilowatt_hour_high: 0)
       expect(record).not_to be_valid
       expect(record.errors[:kilowatt_hour_high]).to be_present
     end
 
-    it 'rate が数値変換できない文字列だと invalid になる' do
-      record = described_class.new(
-        id: 999, plan_id: 1, kilowatt_hour_low: 1, kilowatt_hour_high: 100, rate: 'abc'
-      )
-      expect(record).not_to be_valid
-      expect(record.errors[:rate]).to be_present
-    end
-
     it 'rate が負の数だと invalid になる' do
-      record = described_class.new(
-        id: 999, plan_id: 1, kilowatt_hour_low: 1, kilowatt_hour_high: 100, rate: '-10'
-      )
+      record = build(:usage_based_rate, rate: -10)
       expect(record).not_to be_valid
       expect(record.errors[:rate]).to be_present
     end
@@ -72,12 +54,12 @@ RSpec.describe UsageBasedRate do
 
   describe '#rate' do
     it 'BigDecimal を返す' do
-      record = described_class.new(id: 9999, plan_id: 1, kilowatt_hour_low: 1, kilowatt_hour_high: 120, rate: '19.88')
+      record = create(:usage_based_rate, rate: '19.88')
       expect(record.rate).to be_a(BigDecimal)
     end
 
     it '文字列を精度を保って BigDecimal に変換する' do
-      record = described_class.new(id: 9999, plan_id: 1, kilowatt_hour_low: 1, kilowatt_hour_high: 120, rate: '19.88')
+      record = create(:usage_based_rate, rate: '19.88')
       expect(record.rate).to eq BigDecimal('19.88')
     end
   end

--- a/serverside_challenge_2/challenge/spec/rails_helper.rb
+++ b/serverside_challenge_2/challenge/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/serverside_challenge_2/challenge/spec/requests/api/v1/electricity_bill_simulations_spec.rb
+++ b/serverside_challenge_2/challenge/spec/requests/api/v1/electricity_bill_simulations_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'GET /api/v1/electricity_bill_simulations' do
+  include_context 'with seed data'
+
   let(:valid_params) { { ampere: 30, kwh: 400 } }
 
   context 'with valid params' do

--- a/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
+++ b/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ElectricityBillSimulator do
+  include_context 'with seed data'
+
   subject(:result) { described_class.call(ampere: ampere, kwh: kwh) }
 
   def price_for(plan_name, ampere:, kwh:)

--- a/serverside_challenge_2/challenge/spec/support/shared_contexts/seed_data.rb
+++ b/serverside_challenge_2/challenge/spec/support/shared_contexts/seed_data.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'with seed data' do
+  before { Rails.application.load_seed }
+end


### PR DESCRIPTION
## 要約

Issue #13（ActiveHash/YAML → ActiveRecord/PostgreSQL へのDB移行）を解決する。

- 4テーブル（providers / plans / ampere_based_rates / usage_based_rates）をマイグレーションで作成し、モデルを `ActiveYaml::Base` → `ApplicationRecord` に移行
- YAML ファイルを seeds.rb で読み込む形式は維持し、`find_or_initialize_by(id:)` + `assign_attributes` で再シード可能に
- `active_hash` gem を完全に削除

Closes #13

## 実装してみて発生した追加判断

- **upsert を `find_or_initialize_by(id:)` + `assign_attributes` で実装**: `upsert_all` ではなくこの方式を採用した。YAML の id を保持しながら再シードでレコードを更新できること、モデルバリデーションを通過させてデータ品質を保証できることが理由。シード後に PostgreSQL シーケンスを `setval` で補正し、id 指定 insert 後の自動採番ズレを防ぐ
- **seeds.rb に削除同期を追加**: ActiveRecord 移行後は DB が真実の源になるため、YAML から消したレコードが DB に残り続けると古いマスタが API に出続ける。`reverse_each` で子テーブルから順に「YAML に存在しない id」を destroy_all する3フェーズ構成（削除→upsert→シーケンスリセット）に変更
- **data_consistency_spec から参照整合性テストを削除**: FK 制約が DB レベルで保証するため spec での重複チェックは不要と判断。連続性（usage_based_rate の段間に穴・重複がない）と `metered_only?` の業務的不変条件のみ残した

## テストケース一覧

### `spec/models/` — FactoryBot ベースに書き換え（23 examples）

#### Provider（2 examples）

| ケース | 入力 | 期待 |
|---|---|---|
| name が空だと invalid | name=nil | errors[:name] |
| has_many :plans が引ける | plans を 2 件 create | plans.size == 2 |

#### Plan（7 examples）

| ケース | 入力 | 期待 |
|---|---|---|
| name が空だと invalid | name=nil | errors[:name] |
| provider が nil だと invalid | provider=nil | errors[:provider] |
| belongs_to :provider が引ける | — | Provider インスタンス |
| has_many :ampere_based_rates が引ける | 3 件 create | size == 3 |
| has_many :usage_based_rates が引ける | 2 件 create | size == 2 |
| ampere_based_rates がない場合 metered_only? = true | — | true |
| ampere_based_rates がある場合 metered_only? = false | 1 件 create | false |

#### AmpereBasedRate（6 examples）

| ケース | 入力 | 期待 |
|---|---|---|
| 許容外 ampere（25）は invalid | ampere=25 | errors[:ampere] |
| plan が nil だと invalid | plan=nil | errors[:plan] |
| rate が空だと invalid | rate=nil | errors[:rate] |
| rate が負だと invalid | rate=-100 | errors[:rate] |
| rate が BigDecimal を返す | rate='286.00' | BigDecimal |
| rate が正しい値を返す | rate='286.00' | BigDecimal('286.00') |

#### UsageBasedRate（8 examples）

| ケース | 入力 | 期待 |
|---|---|---|
| 全必須項目が nil だと invalid | plan=nil, low=nil, high=nil, rate=nil | 4フィールドにエラー |
| low > high だと invalid | low=200, high=100 | errors[:kilowatt_hour_low] |
| low > high のエラーが日本語 | low=200, high=100 | 「は kilowatt_hour_high 以下でなければなりません」 |
| low が 0 以下だと invalid | low=0 | errors[:kilowatt_hour_low] |
| high が 0 以下だと invalid | high=0 | errors[:kilowatt_hour_high] |
| rate が負だと invalid | rate=-10 | errors[:rate] |
| rate が BigDecimal を返す | rate='19.88' | BigDecimal |
| rate が正しい値を返す | rate='19.88' | BigDecimal('19.88') |

### `spec/data_consistency_spec.rb` — ActiveRecord 版に書き換え（8 examples）

| ケース | 期待 |
|---|---|
| Plan は 4 件存在する | count == 4 |
| Provider の全レコードが valid | valid? == true |
| Plan の全レコードが valid | valid? == true |
| AmpereBasedRate の全レコードが valid | valid? == true |
| UsageBasedRate の全レコードが valid | valid? == true |
| 各プランの usage_based_rates は low=1 から始まる | first.kilowatt_hour_low == 1 |
| 各プランの usage_based_rates に穴・重複なし | next_low == prev_high + 1 |
| metered_only? なプランは「おうちプラン」のみ | map(:name) == ['おうちプラン'] |