### PR TITLE
Terraform で AWS ECS / RDS / ALB / CloudFront 構築 (#18)

### DIFF
--- a/serverside_challenge_2/challenge/config/environments/production.rb
+++ b/serverside_challenge_2/challenge/config/environments/production.rb
@@ -40,6 +40,10 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
+  # CloudFront が HTTPS 終端して ALB へ HTTP で転送するため X-Forwarded-Proto が http になる
+  # force_ssl の誤検知を防ぐため assume_ssl を有効化する
+  config.assume_ssl = true
+
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
   config.ssl_options = {

--- a/serverside_challenge_2/challenge/config/environments/production.rb
+++ b/serverside_challenge_2/challenge/config/environments/production.rb
@@ -46,13 +46,12 @@ Rails.application.configure do
   #     HTTP→HTTPS 301 リダイレクトを返す（Rails は origin 通信を HTTP と認識するため）
   #   - Rails 7.0 は assume_ssl 未対応（Rails 7.1 以降の機能）
   #
-  # request.ssl? の動作について:
-  #   CloudFront が X-Forwarded-Proto: https を付与し ALB が転送するため
-  #   Rack は request.ssl? == true を正しく返す（X-Forwarded-Proto は無条件に読まれる）。
-  #   また config.action_dispatch.trusted_proxies のデフォルトは 10.0.0.0/8 を含むため
-  #   ALB（10.0.x.x）からのヘッダーは信頼される。
-  #   このアプリは stateless JSON API（Cookie・セッション・URL 生成なし）のため
-  #   force_ssl=false による副作用（Secure Cookie・HSTS の欠如）は無害。
+  # request.ssl? について:
+  #   CloudFront→ALB 間は HTTP (origin_protocol_policy = "http-only") のため、
+  #   ALB が付与する X-Forwarded-Proto は "http" になる。
+  #   よって Rails では request.ssl? == false となるが、このアプリは
+  #   stateless JSON API（Cookie・セッション・URL 生成なし）のため無害。
+  #   エンドユーザーへの HTTPS 強制は CloudFront 側で完結している。
   config.force_ssl = false
 
   # Include generic and useful information about system operation, but avoid logging too much

--- a/serverside_challenge_2/challenge/config/environments/production.rb
+++ b/serverside_challenge_2/challenge/config/environments/production.rb
@@ -40,15 +40,10 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
-  # CloudFront が HTTPS 終端して ALB へ HTTP で転送するため X-Forwarded-Proto が http になる
-  # force_ssl の誤検知を防ぐため assume_ssl を有効化する
-  config.assume_ssl = true
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
-  config.ssl_options = {
-    redirect: { exclude: ->(request) { request.path == '/healthz' } }
-  }
+  # CloudFront の viewer_protocol_policy=redirect-to-https で HTTPS を強制するため
+  # Rails の force_ssl は無効化する。
+  # (Rails 7.0 は assume_ssl 未対応。force_ssl を有効にすると ALB ドメインへ誤リダイレクトする)
+  config.force_ssl = false
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/serverside_challenge_2/challenge/config/environments/production.rb
+++ b/serverside_challenge_2/challenge/config/environments/production.rb
@@ -40,9 +40,19 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
-  # CloudFront の viewer_protocol_policy=redirect-to-https で HTTPS を強制するため
-  # Rails の force_ssl は無効化する。
-  # (Rails 7.0 は assume_ssl 未対応。force_ssl を有効にすると ALB ドメインへ誤リダイレクトする)
+  # SSL の強制は CloudFront の viewer_protocol_policy=redirect-to-https で行う。
+  # Rails の force_ssl を無効にする理由:
+  #   - force_ssl = true にすると ActionDispatch::SSL が ALB ドメインへ
+  #     HTTP→HTTPS 301 リダイレクトを返す（Rails は origin 通信を HTTP と認識するため）
+  #   - Rails 7.0 は assume_ssl 未対応（Rails 7.1 以降の機能）
+  #
+  # request.ssl? の動作について:
+  #   CloudFront が X-Forwarded-Proto: https を付与し ALB が転送するため
+  #   Rack は request.ssl? == true を正しく返す（X-Forwarded-Proto は無条件に読まれる）。
+  #   また config.action_dispatch.trusted_proxies のデフォルトは 10.0.0.0/8 を含むため
+  #   ALB（10.0.x.x）からのヘッダーは信頼される。
+  #   このアプリは stateless JSON API（Cookie・セッション・URL 生成なし）のため
+  #   force_ssl=false による副作用（Secure Cookie・HSTS の欠如）は無害。
   config.force_ssl = false
 
   # Include generic and useful information about system operation, but avoid logging too much

--- a/serverside_challenge_2/terraform/.gitignore
+++ b/serverside_challenge_2/terraform/.gitignore
@@ -1,0 +1,16 @@
+# Terraform の実値変数ファイル（secrets を含むため git 管理しない）
+terraform.tfvars
+
+# Terraform 作業ディレクトリ
+.terraform/
+
+# tfstate（S3 で管理するため local ファイルは git 管理しない）
+*.tfstate
+*.tfstate.backup
+
+# 実行プラン
+*.tfplan
+
+# クラッシュログ
+crash.log
+crash.*.log

--- a/serverside_challenge_2/terraform/.terraform.lock.hcl
+++ b/serverside_challenge_2/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/serverside_challenge_2/terraform/bootstrap/main.tf
+++ b/serverside_challenge_2/terraform/bootstrap/main.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+resource "aws_s3_bucket" "tfstate" {
+  bucket = "enechange-coding-challenge-tfstate"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    Name = "enechange-coding-challenge-tfstate"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket                  = aws_s3_bucket.tfstate.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/serverside_challenge_2/terraform/bootstrap/outputs.tf
+++ b/serverside_challenge_2/terraform/bootstrap/outputs.tf
@@ -1,0 +1,4 @@
+output "tfstate_bucket_name" {
+  value       = aws_s3_bucket.tfstate.bucket
+  description = "tfstate を格納する S3 バケット名。terraform/main.tf の backend.bucket に設定する"
+}

--- a/serverside_challenge_2/terraform/main.tf
+++ b/serverside_challenge_2/terraform/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # bootstrap/ で作成した S3 バケット名を bucket に設定する
+  # use_lockfile は Terraform v1.10+ の S3 native locking（DynamoDB 不要）
+  backend "s3" {
+    bucket       = "enechange-coding-challenge-tfstate"
+    key          = "terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "network" {
+  source  = "./modules/network"
+  project = var.project
+  env     = var.env
+}
+
+module "app" {
+  source               = "./modules/app"
+  project              = var.project
+  env                  = var.env
+  region               = var.region
+  vpc_id               = module.network.vpc_id
+  public_subnet_ids    = module.network.public_subnet_ids
+  sg_alb_id            = module.network.sg_alb_id
+  sg_ecs_id            = module.network.sg_ecs_id
+  rails_image          = var.rails_image
+  cors_allowed_origins = var.cors_allowed_origins
+  origin_verify_secret = var.origin_verify_secret
+}
+
+module "db" {
+  source             = "./modules/db"
+  project            = var.project
+  env                = var.env
+  private_subnet_ids = module.network.private_subnet_ids
+  sg_rds_id          = module.network.sg_rds_id
+}
+
+module "cdn" {
+  source               = "./modules/cdn"
+  project              = var.project
+  env                  = var.env
+  alb_dns_name         = module.app.alb_dns_name
+  origin_verify_secret = var.origin_verify_secret
+}

--- a/serverside_challenge_2/terraform/main.tf
+++ b/serverside_challenge_2/terraform/main.tf
@@ -40,6 +40,9 @@ module "app" {
   rails_image          = var.rails_image
   cors_allowed_origins = var.cors_allowed_origins
   origin_verify_secret = var.origin_verify_secret
+  database_url         = var.database_url
+  secret_key_base      = var.secret_key_base
+  ecs_desired_count    = var.ecs_desired_count
 }
 
 module "db" {

--- a/serverside_challenge_2/terraform/modules/app/main.tf
+++ b/serverside_challenge_2/terraform/modules/app/main.tf
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_log_group" "ecs" {
 }
 
 # ----------------------------------------------------------------
-# Secrets Manager（器のみ作成。値は手動 or CI で投入）
+# Secrets Manager
 # ----------------------------------------------------------------
 resource "aws_secretsmanager_secret" "database_url" {
   name = "${local.name_prefix}/DATABASE_URL"
@@ -52,25 +52,18 @@ resource "aws_secretsmanager_secret" "secret_key_base" {
   }
 }
 
-# プレースホルダー値で AWSCURRENT を作成する。
-# apply 後に正しい値を手動または CI で上書きすること。
-# ignore_changes により以降の apply では Terraform が上書きしない。
+# var.database_url / var.secret_key_base が設定されている場合のみ secret version を作成する。
+# 初回 apply 時は null のままにし、RDS エンドポイント確定後に tfvars へ設定して re-apply する。
 resource "aws_secretsmanager_secret_version" "database_url" {
+  count         = var.database_url != null ? 1 : 0
   secret_id     = aws_secretsmanager_secret.database_url.id
-  secret_string = "PLACEHOLDER"
-
-  lifecycle {
-    ignore_changes = [secret_string]
-  }
+  secret_string = var.database_url
 }
 
 resource "aws_secretsmanager_secret_version" "secret_key_base" {
+  count         = var.secret_key_base != null ? 1 : 0
   secret_id     = aws_secretsmanager_secret.secret_key_base.id
-  secret_string = "PLACEHOLDER"
-
-  lifecycle {
-    ignore_changes = [secret_string]
-  }
+  secret_string = var.secret_key_base
 }
 
 # ----------------------------------------------------------------
@@ -275,7 +268,7 @@ resource "aws_ecs_service" "app" {
   name            = "${local.name_prefix}-app-service"
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.app.arn
-  desired_count   = 1
+  desired_count   = var.ecs_desired_count
   launch_type     = "FARGATE"
 
   # NAT Gateway 省略のため ECS を public subnet に配置してパブリック IP を付与

--- a/serverside_challenge_2/terraform/modules/app/main.tf
+++ b/serverside_challenge_2/terraform/modules/app/main.tf
@@ -1,0 +1,277 @@
+locals {
+  name_prefix = "${var.project}-${var.env}"
+}
+
+# ----------------------------------------------------------------
+# ECR
+# ----------------------------------------------------------------
+resource "aws_ecr_repository" "app" {
+  name                 = "${local.name_prefix}-app"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-app"
+  }
+}
+
+# ----------------------------------------------------------------
+# CloudWatch Logs
+# ----------------------------------------------------------------
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/${local.name_prefix}"
+  retention_in_days = 30
+
+  tags = {
+    Name = "${local.name_prefix}-ecs-logs"
+  }
+}
+
+# ----------------------------------------------------------------
+# Secrets Manager（器のみ作成。値は手動 or CI で投入）
+# ----------------------------------------------------------------
+resource "aws_secretsmanager_secret" "database_url" {
+  name = "${local.name_prefix}/DATABASE_URL"
+
+  tags = {
+    Name = "${local.name_prefix}-database-url"
+  }
+}
+
+resource "aws_secretsmanager_secret" "secret_key_base" {
+  name = "${local.name_prefix}/SECRET_KEY_BASE"
+
+  tags = {
+    Name = "${local.name_prefix}-secret-key-base"
+  }
+}
+
+# ----------------------------------------------------------------
+# IAM
+# ----------------------------------------------------------------
+data "aws_iam_policy_document" "ecs_task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${local.name_prefix}-ecs-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_managed" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "secrets_read" {
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      aws_secretsmanager_secret.database_url.arn,
+      aws_secretsmanager_secret.secret_key_base.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "secrets_read" {
+  name   = "${local.name_prefix}-secrets-read"
+  policy = data.aws_iam_policy_document.secrets_read.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution_secrets" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = aws_iam_policy.secrets_read.arn
+}
+
+resource "aws_iam_role" "task_role" {
+  name               = "${local.name_prefix}-ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+# ----------------------------------------------------------------
+# ECS Cluster
+# ----------------------------------------------------------------
+resource "aws_ecs_cluster" "main" {
+  name = "${local.name_prefix}-cluster"
+
+  tags = {
+    Name = "${local.name_prefix}-cluster"
+  }
+}
+
+# ----------------------------------------------------------------
+# ECS Task Definition
+# ----------------------------------------------------------------
+resource "aws_ecs_task_definition" "app" {
+  family                   = "${local.name_prefix}-app"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "app"
+      image     = var.rails_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 3000
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        {
+          name  = "CORS_ALLOWED_ORIGINS"
+          value = var.cors_allowed_origins
+        },
+        {
+          name  = "RAILS_LOG_TO_STDOUT"
+          value = "true"
+        }
+      ]
+
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = aws_secretsmanager_secret.database_url.arn
+        },
+        {
+          name      = "SECRET_KEY_BASE"
+          valueFrom = aws_secretsmanager_secret.secret_key_base.arn
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ecs.name
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "app"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    Name = "${local.name_prefix}-app-task"
+  }
+}
+
+# ----------------------------------------------------------------
+# ALB
+# ----------------------------------------------------------------
+resource "aws_lb" "main" {
+  # AWS ALB 名の上限は 32 文字。project 変数が長い場合は短縮すること
+  name               = substr("${local.name_prefix}-alb", 0, 32)
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.sg_alb_id]
+  subnets            = var.public_subnet_ids
+
+  tags = {
+    Name = "${local.name_prefix}-alb"
+  }
+}
+
+resource "aws_lb_target_group" "app" {
+  # AWS ターゲットグループ名の上限は 32 文字
+  name        = substr("${local.name_prefix}-app-tg", 0, 32)
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/healthz"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-app-tg"
+  }
+}
+
+# デフォルト: X-Origin-Verify ヘッダーがない場合 403 を返す
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Forbidden"
+      status_code  = "403"
+    }
+  }
+}
+
+# X-Origin-Verify ヘッダーが一致する場合のみ ECS へ転送
+resource "aws_lb_listener_rule" "verify_header" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+
+  condition {
+    http_header {
+      http_header_name = "X-Origin-Verify"
+      values           = [var.origin_verify_secret]
+    }
+  }
+}
+
+# ----------------------------------------------------------------
+# ECS Service
+# ----------------------------------------------------------------
+resource "aws_ecs_service" "app" {
+  name            = "${local.name_prefix}-app-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  # NAT Gateway 省略のため ECS を public subnet に配置してパブリック IP を付与
+  network_configuration {
+    subnets          = var.public_subnet_ids
+    security_groups  = [var.sg_ecs_id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.app.arn
+    container_name   = "app"
+    container_port   = 3000
+  }
+
+  depends_on = [aws_lb_listener_rule.verify_header]
+
+  tags = {
+    Name = "${local.name_prefix}-app-service"
+  }
+}

--- a/serverside_challenge_2/terraform/modules/app/main.tf
+++ b/serverside_challenge_2/terraform/modules/app/main.tf
@@ -52,6 +52,27 @@ resource "aws_secretsmanager_secret" "secret_key_base" {
   }
 }
 
+# プレースホルダー値で AWSCURRENT を作成する。
+# apply 後に正しい値を手動または CI で上書きすること。
+# ignore_changes により以降の apply では Terraform が上書きしない。
+resource "aws_secretsmanager_secret_version" "database_url" {
+  secret_id     = aws_secretsmanager_secret.database_url.id
+  secret_string = "PLACEHOLDER"
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "secret_key_base" {
+  secret_id     = aws_secretsmanager_secret.secret_key_base.id
+  secret_string = "PLACEHOLDER"
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
 # ----------------------------------------------------------------
 # IAM
 # ----------------------------------------------------------------

--- a/serverside_challenge_2/terraform/modules/app/main.tf
+++ b/serverside_challenge_2/terraform/modules/app/main.tf
@@ -1,5 +1,8 @@
 locals {
   name_prefix = "${var.project}-${var.env}"
+  # ALB/TG は 32 文字制限。最長サフィックス "-app-tg"(7文字) を考慮して
+  # プレフィックスを 25 文字以内に収め、末尾ハイフンを除去する
+  name_short = trimsuffix(substr(local.name_prefix, 0, 25), "-")
 }
 
 # ----------------------------------------------------------------
@@ -176,8 +179,7 @@ resource "aws_ecs_task_definition" "app" {
 # ALB
 # ----------------------------------------------------------------
 resource "aws_lb" "main" {
-  # AWS ALB 名の上限は 32 文字。project 変数が長い場合は短縮すること
-  name               = substr("${local.name_prefix}-alb", 0, 32)
+  name               = "${local.name_short}-alb"
   internal           = false
   load_balancer_type = "application"
   security_groups    = [var.sg_alb_id]
@@ -189,8 +191,7 @@ resource "aws_lb" "main" {
 }
 
 resource "aws_lb_target_group" "app" {
-  # AWS ターゲットグループ名の上限は 32 文字
-  name        = substr("${local.name_prefix}-app-tg", 0, 32)
+  name        = "${local.name_short}-app-tg"
   port        = 3000
   protocol    = "HTTP"
   vpc_id      = var.vpc_id

--- a/serverside_challenge_2/terraform/modules/app/outputs.tf
+++ b/serverside_challenge_2/terraform/modules/app/outputs.tf
@@ -1,0 +1,34 @@
+output "alb_dns_name" {
+  value       = aws_lb.main.dns_name
+  description = "ALB の DNS 名（CloudFront のオリジンに設定）"
+}
+
+output "ecr_repository_url" {
+  value       = aws_ecr_repository.app.repository_url
+  description = "ECR リポジトリ URL（docker push 先）"
+}
+
+output "ecs_cluster_name" {
+  value       = aws_ecs_cluster.main.name
+  description = "ECS クラスター名（ワンオフタスク実行時に使用）"
+}
+
+output "ecs_task_definition_arn" {
+  value       = aws_ecs_task_definition.app.arn
+  description = "ECS タスク定義 ARN（ワンオフタスク実行時に使用）"
+}
+
+output "ecs_sg_id" {
+  value       = var.sg_ecs_id
+  description = "ECS セキュリティグループ ID（ワンオフタスク実行時に使用）"
+}
+
+output "database_url_secret_arn" {
+  value       = aws_secretsmanager_secret.database_url.arn
+  description = "DATABASE_URL Secrets Manager ARN（値の手動投入時に使用）"
+}
+
+output "secret_key_base_secret_arn" {
+  value       = aws_secretsmanager_secret.secret_key_base.arn
+  description = "SECRET_KEY_BASE Secrets Manager ARN（値の手動投入時に使用）"
+}

--- a/serverside_challenge_2/terraform/modules/app/variables.tf
+++ b/serverside_challenge_2/terraform/modules/app/variables.tf
@@ -1,0 +1,43 @@
+variable "project" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "public_subnet_ids" {
+  type = list(string)
+}
+
+variable "sg_alb_id" {
+  type = string
+}
+
+variable "sg_ecs_id" {
+  type = string
+}
+
+variable "rails_image" {
+  type        = string
+  description = "Rails API Docker image URI (ECR)"
+}
+
+variable "cors_allowed_origins" {
+  type        = string
+  description = "CORS_ALLOWED_ORIGINS 環境変数の値 (例: https://your-app.vercel.app)"
+}
+
+variable "origin_verify_secret" {
+  type        = string
+  sensitive   = true
+  description = "CloudFront → ALB 間の X-Origin-Verify ヘッダー値"
+}

--- a/serverside_challenge_2/terraform/modules/app/variables.tf
+++ b/serverside_challenge_2/terraform/modules/app/variables.tf
@@ -41,3 +41,20 @@ variable "origin_verify_secret" {
   sensitive   = true
   description = "CloudFront → ALB 間の X-Origin-Verify ヘッダー値"
 }
+
+variable "database_url" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
+variable "secret_key_base" {
+  type      = string
+  sensitive = true
+  default   = null
+}
+
+variable "ecs_desired_count" {
+  type    = number
+  default = 0
+}

--- a/serverside_challenge_2/terraform/modules/cdn/main.tf
+++ b/serverside_challenge_2/terraform/modules/cdn/main.tf
@@ -1,0 +1,56 @@
+locals {
+  name_prefix = "${var.project}-${var.env}"
+}
+
+resource "aws_cloudfront_distribution" "main" {
+  enabled = true
+  comment = "${local.name_prefix} API distribution"
+
+  origin {
+    domain_name = var.alb_dns_name
+    origin_id   = "alb"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+
+    # ALB 側でこのヘッダーを検証し CloudFront 以外からの直接アクセスを拒否する
+    custom_header {
+      name  = "X-Origin-Verify"
+      value = var.origin_verify_secret
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "alb"
+    viewer_protocol_policy = "redirect-to-https"
+
+    # OPTIONS を含む全メソッドを許可（CORS preflight 対応）
+    allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods  = ["GET", "HEAD"]
+
+    # CachingDisabled managed policy: API 用途のためキャッシュ無効化
+    cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+
+    # AllViewerExceptHostHeader: Host ヘッダー以外をオリジンへそのまま転送
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  # *.cloudfront.net の AWS 管理証明書を使用（独自ドメイン不要で HTTPS 化）
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-cf"
+  }
+}

--- a/serverside_challenge_2/terraform/modules/cdn/outputs.tf
+++ b/serverside_challenge_2/terraform/modules/cdn/outputs.tf
@@ -1,0 +1,8 @@
+output "cloudfront_domain_name" {
+  value       = aws_cloudfront_distribution.main.domain_name
+  description = "CloudFront ドメイン名 (xxx.cloudfront.net)。NEXT_PUBLIC_API_URL に設定する"
+}
+
+output "cloudfront_distribution_id" {
+  value = aws_cloudfront_distribution.main.id
+}

--- a/serverside_challenge_2/terraform/modules/cdn/variables.tf
+++ b/serverside_challenge_2/terraform/modules/cdn/variables.tf
@@ -1,0 +1,18 @@
+variable "project" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "alb_dns_name" {
+  type        = string
+  description = "CloudFront のオリジンとなる ALB の DNS 名"
+}
+
+variable "origin_verify_secret" {
+  type        = string
+  sensitive   = true
+  description = "ALB へ転送する X-Origin-Verify カスタムヘッダーの値"
+}

--- a/serverside_challenge_2/terraform/modules/db/main.tf
+++ b/serverside_challenge_2/terraform/modules/db/main.tf
@@ -1,0 +1,41 @@
+locals {
+  name_prefix = "${var.project}-${var.env}"
+}
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${local.name_prefix}-db-subnet-group"
+  subnet_ids = var.private_subnet_ids
+
+  tags = {
+    Name = "${local.name_prefix}-db-subnet-group"
+  }
+}
+
+resource "aws_db_instance" "main" {
+  identifier        = "${local.name_prefix}-db"
+  engine            = "postgres"
+  engine_version    = "15"
+  instance_class    = "db.t4g.micro"
+  allocated_storage = 20
+  storage_type      = "gp2"
+  storage_encrypted = true
+
+  db_name  = "app"
+  username = "postgres"
+
+  # パスワードは RDS が自動生成し Secrets Manager に格納する（tfvars への記載不要）
+  manage_master_user_password = true
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [var.sg_rds_id]
+
+  multi_az            = false
+  publicly_accessible = false
+
+  skip_final_snapshot = true
+  deletion_protection = false
+
+  tags = {
+    Name = "${local.name_prefix}-db"
+  }
+}

--- a/serverside_challenge_2/terraform/modules/db/main.tf
+++ b/serverside_challenge_2/terraform/modules/db/main.tf
@@ -14,7 +14,7 @@ resource "aws_db_subnet_group" "main" {
 resource "aws_db_instance" "main" {
   identifier        = "${local.name_prefix}-db"
   engine            = "postgres"
-  engine_version    = "15"
+  engine_version    = "18"
   instance_class    = "db.t4g.micro"
   allocated_storage = 20
   storage_type      = "gp2"

--- a/serverside_challenge_2/terraform/modules/db/outputs.tf
+++ b/serverside_challenge_2/terraform/modules/db/outputs.tf
@@ -1,0 +1,13 @@
+output "db_endpoint" {
+  value       = aws_db_instance.main.endpoint
+  description = "RDS エンドポイント (host:port)。DATABASE_URL 組み立て時に使用"
+}
+
+output "db_name" {
+  value = aws_db_instance.main.db_name
+}
+
+output "master_user_secret_arn" {
+  value       = tolist(aws_db_instance.main.master_user_secret)[0].secret_arn
+  description = "RDS が自動生成したマスターパスワードの Secrets Manager ARN"
+}

--- a/serverside_challenge_2/terraform/modules/db/variables.tf
+++ b/serverside_challenge_2/terraform/modules/db/variables.tf
@@ -1,0 +1,15 @@
+variable "project" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "sg_rds_id" {
+  type = string
+}

--- a/serverside_challenge_2/terraform/modules/network/main.tf
+++ b/serverside_challenge_2/terraform/modules/network/main.tf
@@ -1,0 +1,147 @@
+locals {
+  name_prefix = "${var.project}-${var.env}"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${local.name_prefix}-vpc"
+  }
+}
+
+resource "aws_subnet" "public" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = ["10.0.1.0/24", "10.0.2.0/24"][count.index]
+  availability_zone = ["ap-northeast-1a", "ap-northeast-1c"][count.index]
+
+  tags = {
+    Name = "${local.name_prefix}-public-${count.index + 1}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = ["10.0.10.0/24", "10.0.11.0/24"][count.index]
+  availability_zone = ["ap-northeast-1a", "ap-northeast-1c"][count.index]
+
+  tags = {
+    Name = "${local.name_prefix}-private-${count.index + 1}"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-igw"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# ECS は public subnet 配置のため NAT Gateway 不要。private subnet は RDS 専用
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${local.name_prefix}-private-rt"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# ALB: CloudFront は IP 固定でないため全許可し、カスタムヘッダーで制限する
+resource "aws_security_group" "alb" {
+  name   = "${local.name_prefix}-alb-sg"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-alb-sg"
+  }
+}
+
+resource "aws_security_group" "ecs" {
+  name   = "${local.name_prefix}-ecs-sg"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-ecs-sg"
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name   = "${local.name_prefix}-rds-sg"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${local.name_prefix}-rds-sg"
+  }
+}

--- a/serverside_challenge_2/terraform/modules/network/outputs.tf
+++ b/serverside_challenge_2/terraform/modules/network/outputs.tf
@@ -1,0 +1,23 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}
+
+output "sg_alb_id" {
+  value = aws_security_group.alb.id
+}
+
+output "sg_ecs_id" {
+  value = aws_security_group.ecs.id
+}
+
+output "sg_rds_id" {
+  value = aws_security_group.rds.id
+}

--- a/serverside_challenge_2/terraform/modules/network/variables.tf
+++ b/serverside_challenge_2/terraform/modules/network/variables.tf
@@ -1,0 +1,7 @@
+variable "project" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}

--- a/serverside_challenge_2/terraform/outputs.tf
+++ b/serverside_challenge_2/terraform/outputs.tf
@@ -1,0 +1,44 @@
+output "cloudfront_domain_name" {
+  value       = module.cdn.cloudfront_domain_name
+  description = "CloudFront ドメイン名。フロントエンドの NEXT_PUBLIC_API_URL に https://<この値> を設定する"
+}
+
+output "ecr_repository_url" {
+  value       = module.app.ecr_repository_url
+  description = "ECR リポジトリ URL。docker build/push 時のイメージタグに使用する"
+}
+
+output "alb_dns_name" {
+  value       = module.app.alb_dns_name
+  description = "ALB DNS 名（CloudFront 経由でアクセスすること）"
+}
+
+output "ecs_cluster_name" {
+  value       = module.app.ecs_cluster_name
+  description = "ECS クラスター名（db:migrate ワンオフタスク実行時に使用）"
+}
+
+output "ecs_task_definition_arn" {
+  value       = module.app.ecs_task_definition_arn
+  description = "ECS タスク定義 ARN（db:migrate ワンオフタスク実行時に使用）"
+}
+
+output "database_url_secret_arn" {
+  value       = module.app.database_url_secret_arn
+  description = "DATABASE_URL の Secrets Manager ARN（aws secretsmanager put-secret-value で値を投入）"
+}
+
+output "secret_key_base_secret_arn" {
+  value       = module.app.secret_key_base_secret_arn
+  description = "SECRET_KEY_BASE の Secrets Manager ARN（aws secretsmanager put-secret-value で値を投入）"
+}
+
+output "db_endpoint" {
+  value       = module.db.db_endpoint
+  description = "RDS エンドポイント (host:port)。DATABASE_URL 組み立て時に使用"
+}
+
+output "rds_master_user_secret_arn" {
+  value       = module.db.master_user_secret_arn
+  description = "RDS が自動生成したマスターパスワードの Secrets Manager ARN"
+}

--- a/serverside_challenge_2/terraform/terraform.tfvars.example
+++ b/serverside_challenge_2/terraform/terraform.tfvars.example
@@ -4,3 +4,15 @@ region                = "ap-northeast-1"
 rails_image           = "123456789.dkr.ecr.ap-northeast-1.amazonaws.com/enechange-coding-challenge-prod-app:latest"
 cors_allowed_origins  = "https://your-app.vercel.app"
 origin_verify_secret  = "CHANGE_ME"  # 推測困難なランダム文字列に変更すること
+
+# ── シークレット設定（2フェーズデプロイ） ───────────────────────────────────
+# Phase 1: 上の変数のみで terraform apply → インフラ構築（ECS は起動しない）
+# Phase 2: 以下を設定して re-apply → secret version 作成 + ECS 起動
+
+ecs_desired_count = 0  # シークレット設定後に 1 へ変更
+
+# terraform output db_endpoint で RDS エンドポイントを確認してから設定
+# database_url = "postgresql://appuser:PASSWORD@ENDPOINT:5432/appdb"
+
+# openssl rand -hex 64 で生成
+# secret_key_base = "your-secret-key-base"

--- a/serverside_challenge_2/terraform/terraform.tfvars.example
+++ b/serverside_challenge_2/terraform/terraform.tfvars.example
@@ -12,7 +12,7 @@ origin_verify_secret  = "CHANGE_ME"  # 推測困難なランダム文字列に�
 ecs_desired_count = 0  # シークレット設定後に 1 へ変更
 
 # terraform output db_endpoint で RDS エンドポイントを確認してから設定
-# database_url = "postgresql://appuser:PASSWORD@ENDPOINT:5432/appdb"
+# database_url = "postgresql://postgres:PASSWORD@ENDPOINT:5432/app"
 
 # openssl rand -hex 64 で生成
 # secret_key_base = "your-secret-key-base"

--- a/serverside_challenge_2/terraform/terraform.tfvars.example
+++ b/serverside_challenge_2/terraform/terraform.tfvars.example
@@ -1,0 +1,6 @@
+project               = "enechange-coding-challenge"
+env                   = "prod"
+region                = "ap-northeast-1"
+rails_image           = "123456789.dkr.ecr.ap-northeast-1.amazonaws.com/enechange-coding-challenge-prod-app:latest"
+cors_allowed_origins  = "https://your-app.vercel.app"
+origin_verify_secret  = "CHANGE_ME"  # 推測困難なランダム文字列に変更すること

--- a/serverside_challenge_2/terraform/variables.tf
+++ b/serverside_challenge_2/terraform/variables.tf
@@ -1,0 +1,33 @@
+variable "project" {
+  type        = string
+  default     = "enechange-coding-challenge"
+  description = "プロジェクト識別子。リソース名のプレフィックスに使用"
+}
+
+variable "env" {
+  type        = string
+  default     = "prod"
+  description = "環境識別子 (prod / stg など)"
+}
+
+variable "region" {
+  type        = string
+  default     = "ap-northeast-1"
+  description = "AWS リージョン"
+}
+
+variable "rails_image" {
+  type        = string
+  description = "Rails API Docker image URI (ECR)"
+}
+
+variable "cors_allowed_origins" {
+  type        = string
+  description = "CORS を許可するオリジン (例: https://your-app.vercel.app)"
+}
+
+variable "origin_verify_secret" {
+  type        = string
+  sensitive   = true
+  description = "CloudFront → ALB 間の X-Origin-Verify ヘッダー値。推測困難な値を設定すること"
+}

--- a/serverside_challenge_2/terraform/variables.tf
+++ b/serverside_challenge_2/terraform/variables.tf
@@ -31,3 +31,23 @@ variable "origin_verify_secret" {
   sensitive   = true
   description = "CloudFront → ALB 間の X-Origin-Verify ヘッダー値。推測困難な値を設定すること"
 }
+
+variable "database_url" {
+  type        = string
+  sensitive   = true
+  default     = null
+  description = "Rails DB 接続 URL。初回 apply 時は null 可。設定後 re-apply で ECS に反映される"
+}
+
+variable "secret_key_base" {
+  type        = string
+  sensitive   = true
+  default     = null
+  description = "Rails の SECRET_KEY_BASE。openssl rand -hex 64 で生成"
+}
+
+variable "ecs_desired_count" {
+  type        = number
+  default     = 0
+  description = "ECS サービスの desired_count。シークレット設定前は 0 のままにする"
+}


### PR DESCRIPTION
## 概要

Issue #18 の Terraform インフラ構築。
独自ドメイン不要で HTTPS 化するため CloudFront を ALB 前段に配置する構成。

## 変更内容

### Rails
- `production.rb` を CloudFront 構成に合わせて修正
  - `force_ssl = false` — CloudFront の `redirect-to-https` が HTTPS を強制するため Rails 側は不要
  - (Rails 7.0 は `assume_ssl` 未対応。`force_ssl=true` のままだと ALB ドメインへ誤リダイレクトが発生する)
  - CloudFront→ALB 間は HTTP-only のため `X-Forwarded-Proto: http` が付与され `request.ssl? == false` になるが、stateless JSON API のため無害

### Terraform ディレクトリ構成

```
serverside_challenge_2/terraform/
├── main.tf                   # Backend (S3 native locking), Provider, module 呼び出し
├── variables.tf
├── outputs.tf
├── terraform.tfvars.example
├── .gitignore
├── bootstrap/                # tfstate 用 S3 バケット（初回のみ apply）
└── modules/
    ├── network/              # VPC / Subnet / IGW / SG
    ├── app/                  # ECR / ECS / ALB / IAM / CloudWatch / SecretsManager
    ├── db/                   # RDS PostgreSQL
    └── cdn/                  # CloudFront Distribution
```

### 設計上のポイント

| 項目 | 内容 |
|---|---|
| HTTPS | CloudFront の `*.cloudfront.net` 証明書を利用。独自ドメイン・ACM 不要 |
| ALB 直接アクセス制限 | `X-Origin-Verify` カスタムヘッダーで制御。ヘッダーなしは 403 |
| NAT Gateway 省略 | ECS を public subnet + `assign_public_ip=true` で配置（月 ~$45 削減） |
| tfstate locking | Terraform v1.10+ の S3 native locking (`use_lockfile=true`)。DynamoDB 不要 |
| RDS パスワード | `manage_master_user_password=true` で自動生成 → tfvars にパスワードを書かない |
| SecretsManager | `database_url` / `secret_key_base` を Terraform 変数で受け取り `aws_secretsmanager_secret_version` を作成。`ecs_desired_count` 変数（default=0）で2フェーズデプロイを実現 |

### 2フェーズデプロイ手順

```
# Phase 1: インフラ構築（ECS は起動しない）
terraform apply

# terraform output db_endpoint で RDS エンドポイントを確認
# terraform.tfvars に以下を追加:
#   database_url      = "postgresql://postgres:PASSWORD@ENDPOINT:5432/app"
#   secret_key_base   = "$(openssl rand -hex 64)"
#   ecs_desired_count = 1

# Phase 2: シークレット注入 + ECS 起動
terraform apply
```

## 検証結果

- [x] `terraform validate` — 構文エラーなし
- [x] `terraform plan` — 34 リソース、エラーなし
- [x] `terraform apply` — 全リソース作成済み
- [x] `terraform.tfvars` に `database_url` / `secret_key_base` / `ecs_desired_count=1` を設定して re-apply → `aws_secretsmanager_secret_version` 作成確認
- [x] `db:migrate` / `db:seed` 完了（exitCode: 0）
- [x] `curl https://d1qlohhwjtfdr1.cloudfront.net/healthz` → 200 `{"status":"ok"}`
- [x] `curl https://d1qlohhwjtfdr1.cloudfront.net/api/v1/electricity_bill_simulations?ampere=30&kwh=200` → 200 正常レスポンス

## 関連
- Closes #18
- 親 Issue: #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)