### PR TITLE
本番デプロイと疎通確認 (Vercel + AWS) (closes #19)

### DIFF
--- a/serverside_challenge_2/challenge/README.md
+++ b/serverside_challenge_2/challenge/README.md
@@ -130,17 +130,22 @@ docker buildx build --platform linux/amd64 \
   -t 866642010952.dkr.ecr.ap-northeast-1.amazonaws.com/enechange-coding-challenge-prod-app:latest \
   --push .
 
-# 3. ECS Service を最新タスク定義で更新
-cd ../terraform && terraform apply
+# 3. ECS Service を強制的に最新イメージで再デプロイ
+# (:latest タグは terraform apply では差分が出ないため --force-new-deployment を使う)
+aws ecs update-service \
+  --cluster enechange-coding-challenge-prod-cluster \
+  --service enechange-coding-challenge-prod-app-service \
+  --force-new-deployment \
+  --region ap-northeast-1
 ```
 
 ### DB マイグレーション / Seed (ECS ワンオフタスク)
 
 ```sh
 CLUSTER=enechange-coding-challenge-prod-cluster
-TASKDEF=$(cd serverside_challenge_2/terraform && terraform output -raw ecs_task_definition_arn)
-SUBNET=$(cd serverside_challenge_2/terraform && terraform output -json public_subnet_ids | jq -r '.[0]')
-SG=$(cd serverside_challenge_2/terraform && terraform output -raw ecs_sg_id)
+TASKDEF=$(cd ../terraform && terraform output -raw ecs_task_definition_arn)
+SUBNET=$(cd ../terraform && terraform output -json public_subnet_ids | jq -r '.[0]')
+SG=$(cd ../terraform && terraform output -raw ecs_sg_id)
 
 # マイグレーション
 aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASKDEF" \

--- a/serverside_challenge_2/challenge/README.md
+++ b/serverside_challenge_2/challenge/README.md
@@ -64,6 +64,8 @@ DB 接続を確認するヘルスチェックエンドポイント。
 - 正常時: 200 OK, `{"status":"ok"}`
 - DB 接続失敗時: 503 Service Unavailable, `{"status":"error"}`
 
+本番: `https://d1qlohhwjtfdr1.cloudfront.net/healthz`
+
 ## 本番ビルド
 
 ```sh
@@ -101,3 +103,54 @@ docker run --rm \
 ```
 
 起動後、`curl http://localhost:3000/healthz` で疎通確認。
+
+## 本番デプロイ (AWS ECS + Terraform)
+
+インフラは Terraform で管理しています。詳細は `serverside_challenge_2/terraform/` を参照。
+
+### 本番環境情報
+
+| 項目 | 値 |
+|---|---|
+| CloudFront (API) | `https://d1qlohhwjtfdr1.cloudfront.net` |
+| ECS クラスター | `enechange-coding-challenge-prod-cluster` |
+| ECR リポジトリ | `866642010952.dkr.ecr.ap-northeast-1.amazonaws.com/enechange-coding-challenge-prod-app` |
+
+### デプロイ手順
+
+```sh
+# 1. ECR にログイン
+aws ecr get-login-password --region ap-northeast-1 \
+  | docker login --username AWS --password-stdin \
+    866642010952.dkr.ecr.ap-northeast-1.amazonaws.com
+
+# 2. イメージをビルドして push (Apple Silicon の場合は --platform linux/amd64 必須)
+docker buildx build --platform linux/amd64 \
+  -f Dockerfile.production \
+  -t 866642010952.dkr.ecr.ap-northeast-1.amazonaws.com/enechange-coding-challenge-prod-app:latest \
+  --push .
+
+# 3. ECS Service を最新タスク定義で更新
+cd ../terraform && terraform apply
+```
+
+### DB マイグレーション / Seed (ECS ワンオフタスク)
+
+```sh
+CLUSTER=enechange-coding-challenge-prod-cluster
+TASKDEF=$(cd serverside_challenge_2/terraform && terraform output -raw ecs_task_definition_arn)
+SUBNET=$(cd serverside_challenge_2/terraform && terraform output -json public_subnet_ids | jq -r '.[0]')
+SG=$(cd serverside_challenge_2/terraform && terraform output -raw ecs_sg_id)
+
+# マイグレーション
+aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASKDEF" \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[$SUBNET],securityGroups=[$SG],assignPublicIp=ENABLED}" \
+  --overrides '{"containerOverrides":[{"name":"app","command":["bundle","exec","rails","db:migrate"]}]}'
+
+# Seed 投入 (冪等)
+aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASKDEF" \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[$SUBNET],securityGroups=[$SG],assignPublicIp=ENABLED}" \
+  --overrides '{"containerOverrides":[{"name":"app","command":["bundle","exec","rails","db:seed"]}]}'
+```

--- a/serverside_challenge_2/frontend/README.md
+++ b/serverside_challenge_2/frontend/README.md
@@ -108,10 +108,17 @@ Vitest + Testing Library + jsdom で 16 テストを実行。
 
 ## 本番ビルド & デプロイ
 
-Vercel へのデプロイを想定:
+### 本番環境情報
+
+| 項目 | 値 |
+|---|---|
+| Vercel URL | `https://coding-challenge-umber-beta.vercel.app` |
+| `NEXT_PUBLIC_API_URL` | `https://d1qlohhwjtfdr1.cloudfront.net` |
+
+### Vercel デプロイ手順
 
 1. Vercel プロジェクトの **Root Directory** を `serverside_challenge_2/frontend` に設定
-2. 環境変数 `NEXT_PUBLIC_API_URL` に CloudFront URL を設定
+2. Environment Variables に `NEXT_PUBLIC_API_URL = https://d1qlohhwjtfdr1.cloudfront.net` を追加
 3. `npm run build` が通ることを確認してから deploy
 
 ## 既知の制約

--- a/serverside_challenge_2/terraform/bootstrap/.terraform.lock.hcl
+++ b/serverside_challenge_2/terraform/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/serverside_challenge_2/terraform/outputs.tf
+++ b/serverside_challenge_2/terraform/outputs.tf
@@ -42,3 +42,13 @@ output "rds_master_user_secret_arn" {
   value       = module.db.master_user_secret_arn
   description = "RDS が自動生成したマスターパスワードの Secrets Manager ARN"
 }
+
+output "public_subnet_ids" {
+  value       = module.network.public_subnet_ids
+  description = "ECS run-task 実行時の subnet ID リスト"
+}
+
+output "ecs_sg_id" {
+  value       = module.app.ecs_sg_id
+  description = "ECS run-task 実行時のセキュリティグループ ID"
+}


### PR DESCRIPTION
## Summary

- Terraform outputs に `public_subnet_ids` / `ecs_sg_id` を追加 (ECS run-task 実行に必要)
- `bootstrap/.terraform.lock.hcl` を git 管理対象に追加
- CORS を本番 Vercel ドメイン (`coding-challenge-umber-beta.vercel.app`) に更新し terraform apply 実施
- `challenge/README.md` に本番 URL・ECR push 手順・ECS run-task 手順を追記
- `frontend/README.md` に本番 Vercel URL と `NEXT_PUBLIC_API_URL` の確定値を追記

## 本番環境

| 項目 | URL |
|---|---|
| フロントエンド (Vercel) | https://coding-challenge-umber-beta.vercel.app |
| API (CloudFront) | https://d1qlohhwjtfdr1.cloudfront.net |

## Test plan

- [x] `GET https://d1qlohhwjtfdr1.cloudfront.net/healthz` → 200 `{"status":"ok"}`
- [x] `GET https://d1qlohhwjtfdr1.cloudfront.net/api/v1/electricity_bill_simulations?ampere=30&kwh=200` → 200 + JSON
- [x] ALB 直叩き → 403 (X-Origin-Verify 検証)
- [x] CORS: `Access-Control-Allow-Origin: https://coding-challenge-umber-beta.vercel.app`
- [x] Vercel フロントエンド → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)