### PR TITLE
fix: RuboCop 違反 12 件を解消

### DIFF
--- a/serverside_challenge_2/challenge/.rubocop.yml
+++ b/serverside_challenge_2/challenge/.rubocop.yml
@@ -38,6 +38,15 @@ Metrics/BlockLength:
     - "config/routes.rb"
     - "config/environments/*.rb"
 
+# マイグレーションは生成 DSL で長くなりがちなため除外する
+Metrics/AbcSize:
+  Exclude:
+    - "db/migrate/**/*.rb"
+
+Metrics/MethodLength:
+  Exclude:
+    - "db/migrate/**/*.rb"
+
 RSpec/ExampleLength:
   Max: 10
 

--- a/serverside_challenge_2/challenge/app/models/usage_based_rate.rb
+++ b/serverside_challenge_2/challenge/app/models/usage_based_rate.rb
@@ -4,7 +4,7 @@ class UsageBasedRate < ApplicationRecord
   belongs_to :plan
 
   validates :kilowatt_hour_low, :kilowatt_hour_high, presence: true,
-            numericality: { only_integer: true, greater_than: 0 }
+                                                     numericality: { only_integer: true, greater_than: 0 }
   validates :rate, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validate :low_must_not_exceed_high
 

--- a/serverside_challenge_2/challenge/db/migrate/20260507000000_create_master_tables.rb
+++ b/serverside_challenge_2/challenge/db/migrate/20260507000000_create_master_tables.rb
@@ -14,7 +14,7 @@ class CreateMasterTables < ActiveRecord::Migration[7.0]
       t.string :name, null: false
       t.timestamps
 
-      t.index [:provider_id, :name], unique: true
+      t.index %i[provider_id name], unique: true
     end
 
     create_table :ampere_based_rates do |t|
@@ -23,7 +23,7 @@ class CreateMasterTables < ActiveRecord::Migration[7.0]
       t.decimal :rate, precision: 10, scale: 2, null: false
       t.timestamps
 
-      t.index [:plan_id, :ampere], unique: true
+      t.index %i[plan_id ampere], unique: true
       t.check_constraint 'rate >= 0', name: 'ampere_based_rates_rate_non_negative'
       t.check_constraint 'ampere IN (10, 15, 20, 30, 40, 50, 60)', name: 'ampere_based_rates_ampere_allowed'
     end
@@ -35,8 +35,8 @@ class CreateMasterTables < ActiveRecord::Migration[7.0]
       t.decimal :rate, precision: 10, scale: 2, null: false
       t.timestamps
 
-      t.index [:plan_id, :kilowatt_hour_low, :kilowatt_hour_high], unique: true,
-              name: 'index_usage_based_rates_on_plan_and_range'
+      t.index %i[plan_id kilowatt_hour_low kilowatt_hour_high], unique: true,
+                                                                name: 'index_usage_based_rates_on_plan_and_range'
       t.check_constraint 'rate >= 0', name: 'usage_based_rates_rate_non_negative'
       t.check_constraint 'kilowatt_hour_low > 0', name: 'usage_based_rates_low_positive'
       t.check_constraint 'kilowatt_hour_low <= kilowatt_hour_high', name: 'usage_based_rates_low_le_high'

--- a/serverside_challenge_2/challenge/spec/factories/usage_based_rates.rb
+++ b/serverside_challenge_2/challenge/spec/factories/usage_based_rates.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :usage_based_rate do
     association :plan
-    sequence(:kilowatt_hour_low)  { |n| (n - 1) * 100 + 1 }
+    sequence(:kilowatt_hour_low)  { |n| ((n - 1) * 100) + 1 }
     sequence(:kilowatt_hour_high) { |n| n * 100 }
     rate { '19.88' }
   end

--- a/serverside_challenge_2/challenge/spec/requests/healthz_spec.rb
+++ b/serverside_challenge_2/challenge/spec/requests/healthz_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Healthz', type: :request do
   describe 'GET /healthz' do
-    context '正常系' do
+    context 'when DB 接続が健全なとき' do
       it '200 status と {"status":"ok"} を返す' do
         get '/healthz'
 
@@ -13,7 +13,7 @@ RSpec.describe 'Healthz', type: :request do
       end
     end
 
-    context 'DB 接続失敗時' do
+    context 'when DB 接続が失敗するとき' do
       before do
         allow(ActiveRecord::Base.connection).to receive(:execute).and_raise(StandardError, 'Connection lost')
       end

--- a/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
+++ b/serverside_challenge_2/challenge/spec/services/electricity_bill_simulator_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe ElectricityBillSimulator do
-  include_context 'with seed data'
-
   subject(:result) { described_class.call(ampere: ampere, kwh: kwh) }
+
+  include_context 'with seed data'
 
   def price_for(plan_name, ampere:, kwh:)
     described_class.call(ampere: ampere, kwh: kwh)
@@ -66,7 +66,6 @@ RSpec.describe ElectricityBillSimulator do
         expect(plan_names).to include('おうちプラン')
       end
     end
-
   end
 
   describe '横断' do


### PR DESCRIPTION
## Summary

`bundle exec rubocop` の 12 件の違反を解消する。Test plan 実行中に検出された既存違反のクリーンアップ。

| Commit | 対応 |
|---|---|
| `style: rubocop -A の自動修正を適用` | HashAlignment / SymbolArray (%i 化) / EmptyLines / LeadingSubject 等 8 件 |
| `chore(rubocop): db/migrate を Metrics/AbcSize, MethodLength から除外` | マイグレーションは Rails 生成 DSL を素直に並べる性質上、慣例に倣い除外 (2 件) |
| `test(healthz): context を when 始まりにし RSpec/ContextWording を解消` | `'正常系'` → `'when DB 接続が健全なとき'`、`'DB 接続失敗時'` → `'when DB 接続が失敗するとき'` (2 件) |

## Test plan

- [x] `bundle exec rspec` 74 examples, 0 failures
- [x] `bundle exec rubocop` no offenses detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)