### PR TITLE
fix(healthz): log level を error に変更し rescue 範囲の WHY コメントを追加

### DIFF
--- a/serverside_challenge_2/challenge/app/controllers/healthz_controller.rb
+++ b/serverside_challenge_2/challenge/app/controllers/healthz_controller.rb
@@ -5,7 +5,9 @@ class HealthzController < ApplicationController
     ActiveRecord::Base.connection.execute('SELECT 1')
     render json: { status: 'ok' }, status: :ok
   rescue StandardError => e
-    Rails.logger.warn("Healthz DB check failed: #{e.class}: #{e.message}")
+    # Healthz は「アプリ全体の健全性」を 200/503 で表現するエンドポイント。
+    # 想定外例外も含めて広く捕捉し、503 として ALB に伝える。
+    Rails.logger.error("Healthz check failed: #{e.class}: #{e.message}")
     render json: { status: 'error' }, status: :service_unavailable
   end
 end

--- a/serverside_challenge_2/challenge/spec/requests/healthz_spec.rb
+++ b/serverside_challenge_2/challenge/spec/requests/healthz_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe 'Healthz', type: :request do
         expect(response.parsed_body).to eq({ 'status' => 'error' })
       end
 
-      it 'Rails.logger.warn が呼ばれる' do
-        allow(Rails.logger).to receive(:warn)
+      it 'Rails.logger.error が呼ばれる' do
+        allow(Rails.logger).to receive(:error)
 
         get '/healthz'
 
-        expect(Rails.logger).to have_received(:warn).with(/Healthz DB check failed/)
+        expect(Rails.logger).to have_received(:error).with(/Healthz check failed/)
       end
     end
   end


### PR DESCRIPTION
## Summary

`HealthzController` の修正。シコードレビュー (M1) の議論結果を反映:

1. **log level を `warn` → `error` に変更**: 503 を返すヘルスチェック失敗は「人間の調査が必要」な事象 (RDS フェイルオーバー / コネクションプール枯渇 / SG 変更 等)。CloudWatch のアラート設計で `error` レベルを拾うのが運用上の慣例。
2. **`rescue StandardError` の意図を WHY コメントで明示**: Healthz は「アプリ全体の健全性」を 200/503 で表現する場所。普通のコントローラと違い、想定外例外 (NoMethodError 等の実装バグ) も 503 として ALB に伝えることが正しい。この意図がコードからは読み取れないため、WHY を残す。
3. **メッセージ文言を整合**: "Healthz DB check failed" → "Healthz check failed" (DB に限らない捕捉のため)。

## 議論経緯

レビュー初稿では rescue 範囲を `ActiveRecord::ActiveRecordError, PG::Error` に絞ることも提案したが、議論の結果、Healthz の特殊性 (失敗の種類を区別する場所ではなく、失敗を 503 に変換する場所) を考慮して **`StandardError` 全捕捉が正解** と再評価。log level の指摘のみ採用。

## Test plan

- [x] `bundle exec rspec spec/requests/healthz_spec.rb`: 3 examples, 0 failures
- [x] `bundle exec rubocop`: no offenses
- [x] 既存テスト (`Rails.logger.warn` 期待) を `error` 期待に追随

## 関連

- アラート設計時のメモ: ALB ヘルスチェックは `healthy_threshold` / `unhealthy_threshold` を複数回失敗で初めて発火するため、`error` レベル単発でアラート疲労になることはない (CloudWatch Alarm 側で N 分間 M 回のしきい値設定で吸収可能)

🤖 Generated with [Claude Code](https://claude.com/claude-code)