### PR TITLE
fix: PR #25 レビュー指摘に対応

### DIFF
--- a/serverside_challenge_2/challenge/db/migrate/20260513000000_tighten_usage_based_rates_range_constraint.rb
+++ b/serverside_challenge_2/challenge/db/migrate/20260513000000_tighten_usage_based_rates_range_constraint.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TightenUsageBasedRatesRangeConstraint < ActiveRecord::Migration[7.0]
+  def up
+    remove_check_constraint :usage_based_rates, name: 'usage_based_rates_low_le_high'
+    add_check_constraint :usage_based_rates,
+                         'kilowatt_hour_low < kilowatt_hour_high',
+                         name: 'usage_based_rates_low_lt_high'
+  end
+
+  def down
+    remove_check_constraint :usage_based_rates, name: 'usage_based_rates_low_lt_high'
+    add_check_constraint :usage_based_rates,
+                         'kilowatt_hour_low <= kilowatt_hour_high',
+                         name: 'usage_based_rates_low_le_high'
+  end
+end

--- a/serverside_challenge_2/challenge/db/schema.rb
+++ b/serverside_challenge_2/challenge/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_07_000000) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_13_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_07_000000) do
     t.datetime "updated_at", null: false
     t.index ["plan_id", "kilowatt_hour_low", "kilowatt_hour_high"], name: "index_usage_based_rates_on_plan_and_range", unique: true
     t.index ["plan_id"], name: "index_usage_based_rates_on_plan_id"
-    t.check_constraint "kilowatt_hour_low <= kilowatt_hour_high", name: "usage_based_rates_low_le_high"
+    t.check_constraint "kilowatt_hour_low < kilowatt_hour_high", name: "usage_based_rates_low_lt_high"
     t.check_constraint "kilowatt_hour_low > 0", name: "usage_based_rates_low_positive"
     t.check_constraint "rate >= 0::numeric", name: "usage_based_rates_rate_non_negative"
   end

--- a/serverside_challenge_2/terraform/modules/app/main.tf
+++ b/serverside_challenge_2/terraform/modules/app/main.tf
@@ -271,7 +271,8 @@ resource "aws_ecs_service" "app" {
   desired_count   = var.ecs_desired_count
   launch_type     = "FARGATE"
 
-  # NAT Gateway 省略のため ECS を public subnet に配置してパブリック IP を付与
+  # 課題環境では NAT Gateway / VPC Endpoint のコストを避けるため public subnet に配置する。
+  # inbound は ECS security group で ALB からの 3000/tcp のみに制限する。
   network_configuration {
     subnets          = var.public_subnet_ids
     security_groups  = [var.sg_ecs_id]

--- a/serverside_challenge_2/terraform/modules/cdn/main.tf
+++ b/serverside_challenge_2/terraform/modules/cdn/main.tf
@@ -11,13 +11,15 @@ resource "aws_cloudfront_distribution" "main" {
     origin_id   = "alb"
 
     custom_origin_config {
-      http_port              = 80
-      https_port             = 443
+      http_port  = 80
+      https_port = 443
+      # 独自ドメイン + ACM を使わない低コスト構成のため、viewer 側 HTTPS は
+      # CloudFront で終端し、origin の ALB へは HTTP で転送する。
       origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
 
-    # ALB 側でこのヘッダーを検証し CloudFront 以外からの直接アクセスを拒否する
+    # ALB 側でこのヘッダーを検証し CloudFront 以外からの直接アクセスを拒否する簡易策。
     custom_header {
       name  = "X-Origin-Verify"
       value = var.origin_verify_secret

--- a/serverside_challenge_2/terraform/terraform.tfvars.example
+++ b/serverside_challenge_2/terraform/terraform.tfvars.example
@@ -3,7 +3,7 @@ env                   = "prod"
 region                = "ap-northeast-1"
 rails_image           = "123456789.dkr.ecr.ap-northeast-1.amazonaws.com/enechange-coding-challenge-prod-app:latest"
 cors_allowed_origins  = "https://your-app.vercel.app"
-origin_verify_secret  = "CHANGE_ME"  # 推測困難なランダム文字列に変更すること
+origin_verify_secret  = "replace-with-random-origin-secret"  # 推測困難なランダム文字列に変更すること
 
 # ── シークレット設定（2フェーズデプロイ） ───────────────────────────────────
 # Phase 1: 上の変数のみで terraform apply → インフラ構築（ECS は起動しない）

--- a/serverside_challenge_2/terraform/variables.tf
+++ b/serverside_challenge_2/terraform/variables.tf
@@ -30,6 +30,11 @@ variable "origin_verify_secret" {
   type        = string
   sensitive   = true
   description = "CloudFront → ALB 間の X-Origin-Verify ヘッダー値。推測困難な値を設定すること"
+
+  validation {
+    condition     = var.origin_verify_secret != "CHANGE_ME"
+    error_message = "origin_verify_secret must be changed from the example value."
+  }
 }
 
 variable "database_url" {
@@ -50,4 +55,17 @@ variable "ecs_desired_count" {
   type        = number
   default     = 0
   description = "ECS サービスの desired_count。シークレット設定前は 0 のままにする"
+
+  validation {
+    condition     = var.ecs_desired_count >= 0
+    error_message = "ecs_desired_count must be greater than or equal to 0."
+  }
+
+  validation {
+    condition = (
+      var.ecs_desired_count == 0 ||
+      (var.database_url != null && var.secret_key_base != null)
+    )
+    error_message = "database_url and secret_key_base must be set when ecs_desired_count is greater than 0."
+  }
 }


### PR DESCRIPTION
## Summary

PR #25 のレビュー指摘を踏まえて、Terraform 入力値の不整合と従量課金レンジ制約のズレを修正します。

インフラ設計判断の詳細は README には含めず、手元の技術課題メモに整理しました。

## Changes

- Terraform validation を追加
  - `origin_verify_secret` がサンプル値のままにならないようにする
  - `ecs_desired_count` は 0 以上に制限
  - ECS を起動する場合は `database_url` / `secret_key_base` を必須化
- Terraform コメントを補足
  - CloudFront -> ALB が HTTP である理由
  - ECS public subnet 配置と inbound 制限の意図
- `usage_based_rates` の DB check constraint を model validation に合わせて `low < high` に変更

## Test plan

- [x] `docker compose build web`
- [x] `docker compose run --rm web bundle exec rails db:migrate`
- [x] `docker compose run --rm web bash -lc 'bundle exec rails db:rollback STEP=1 && bundle exec rails db:migrate'`
- [x] `docker compose run --rm web bundle exec rspec` (70 examples, 0 failures)
- [x] `docker compose run --rm web bundle exec rubocop`
- [x] `npm test -- --run` (16 tests)
- [x] `terraform -chdir=../terraform fmt -check variables.tf modules/app/main.tf modules/cdn/main.tf`
- [x] `terraform -chdir=../terraform validate`
- [x] `docker compose run --rm web bundle exec rspec spec/models/usage_based_rate_spec.rb` after README removal amend
