### PR TITLE
docs: README の実態との不整合を修正

### DIFF
--- a/serverside_challenge_2/challenge/README.md
+++ b/serverside_challenge_2/challenge/README.md
@@ -96,7 +96,7 @@ docker build -f Dockerfile.production -t app:prod .
 ```sh
 docker run --rm \
   -e RAILS_ENV=production \
-  -e SECRET_KEY_BASE=$(openssl rand -hex 32) \
+  -e SECRET_KEY_BASE=$(openssl rand -hex 64) \
   -e DATABASE_URL="postgresql://postgres:password@host.docker.internal:5432/app_production" \
   -p 3000:3000 \
   app:prod
@@ -151,11 +151,13 @@ SG=$(cd ../terraform && terraform output -raw ecs_sg_id)
 aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASKDEF" \
   --launch-type FARGATE \
   --network-configuration "awsvpcConfiguration={subnets=[$SUBNET],securityGroups=[$SG],assignPublicIp=ENABLED}" \
-  --overrides '{"containerOverrides":[{"name":"app","command":["bundle","exec","rails","db:migrate"]}]}'
+  --overrides '{"containerOverrides":[{"name":"app","command":["bundle","exec","rails","db:migrate"]}]}' \
+  --region ap-northeast-1
 
 # Seed 投入 (冪等)
 aws ecs run-task --cluster "$CLUSTER" --task-definition "$TASKDEF" \
   --launch-type FARGATE \
   --network-configuration "awsvpcConfiguration={subnets=[$SUBNET],securityGroups=[$SG],assignPublicIp=ENABLED}" \
-  --overrides '{"containerOverrides":[{"name":"app","command":["bundle","exec","rails","db:seed"]}]}'
+  --overrides '{"containerOverrides":[{"name":"app","command":["bundle","exec","rails","db:seed"]}]}' \
+  --region ap-northeast-1
 ```

--- a/serverside_challenge_2/frontend/README.md
+++ b/serverside_challenge_2/frontend/README.md
@@ -88,7 +88,7 @@ GET /api/v1/electricity_bill_simulations?ampere={A}&kwh={kWh}
 ```json
 { "data": [{ "provider_name": "...", "plan_name": "...", "price": 8010 }] }
 ```
-- `price` は整数（円）、price ASC → provider_id ASC → plan_id ASC で並ぶ
+- `price` は整数（円）、price ASC → provider_name ASC → plan_name ASC で並ぶ
 
 エラー 400:
 ```json
@@ -101,7 +101,7 @@ GET /api/v1/electricity_bill_simulations?ampere={A}&kwh={kWh}
 npm run test
 ```
 
-Vitest + Testing Library + jsdom で 16 テストを実行。
+Vitest + Testing Library + jsdom で 17 テストを実行。
 - `api.test.ts`: fetchSimulations の HTTP レイヤーテスト
 - `simulation-form.test.tsx`: Zod バリデーション / submit フロー
 - `simulation-result.test.tsx`: loading / error / empty / results の表示テスト


### PR DESCRIPTION
## Summary

- フロントエンド README: 並び順のタイブレーカーを `provider_id/plan_id` → `provider_name/plan_name` に修正（実装は name の文字列昇順）
- フロントエンド README: テスト件数を `16` → `17` に修正（api: 5 + form: 7 + result: 5）
- バックエンド README: `SECRET_KEY_BASE` 生成コマンドを `hex 32` → `hex 64` に修正（`terraform/variables.tf` の記述と統一）
- バックエンド README: `aws ecs run-task` コマンドに `--region ap-northeast-1` を追加（`update-service` コマンドとの統一）

## Test plan

- [x] 変更はドキュメントのみ。コード・動作への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)